### PR TITLE
Add a 'make remote' target.  Fix minor bikeshed breakage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ remote: index.bs
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
 	                       -F die-on=warning \
-	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
 	                       -F file=@index.bs) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat build/index.html; echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build/index.html: index.bs Makefile
 	bikeshed --die-on=warning spec $< $@
 
 remote: index.bs
+	mkdir -p build
 	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
 	                       --output build/index.html \
 	                       --write-out "%{http_code}" \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 #
 #    npm install -g doctoc
 
-.PHONY: all publish clean update-explainer-toc
+SHELL=/bin/bash -o pipefail
+.PHONY: all publish clean update-explainer-toc remote
 .SUFFIXES: .bs .html
 
 all: publish update-explainer-toc
@@ -25,3 +26,17 @@ update-explainer-toc: README.md Makefile
 build/index.html: index.bs Makefile
 	mkdir -p build
 	bikeshed --die-on=warning spec $< $@
+
+remote: index.bs
+	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	                       --output build/index.html \
+	                       --write-out "%{http_code}" \
+	                       --header "Accept: text/plain, text/html" \
+	                       -F die-on=warning \
+	                       -F md-Text-Macro="COMMIT-SHA LOCAL COPY" \
+	                       -F file=@index.bs) && \
+	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
+		echo ""; cat build/index.html; echo ""; \
+		rm -f build/index.html; \
+		exit 22 \
+	);

--- a/index.bs
+++ b/index.bs
@@ -70,8 +70,8 @@ with extra information beyond what's necessary to identify the page a user wants
 to navigate to. This information can be placed almost anywhere inside the URL.
 
 <dfn>Navigational tracking</dfn> refers to the general use of one or more
-[[HTML#browsing-the-web|navigations]] to identify that a user on one site is the
-same person as a user on another site. Navigations transmit information
+[[HTML#navigating-across-documents|navigations]] to identify that a user on one
+site is the same person as a user on another site. Navigations transmit information
 cross-site in a few different ways, including in the target URL, which might be
 [=link decoration|decorated=], and in the timing of the request.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 15, 2023, 5:17 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fprivacycg%2Fnav-tracking-mitigations%2F14754f6aa51d6441ce1cc0de52aa04fc89157aef%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't find section '#browsing-the-web' in spec 'html':
[[HTML#browsing-the-web|navigations]]
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20privacycg/nav-tracking-mitigations%2333.)._
</details>
