### PR TITLE
Drafting Start/End navigation monkey patches

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -408,7 +408,8 @@ given a [=request=] |request|, perform the following steps:
         [=bc-traversable|top-level traversable=].
     1. [=Assert=]: |topLevelTraversable|'s
         [=top-level traversable/bounce tracking record=] is not null.
-    1. [=set/Append=] |origin|'s [=host=] to |topLevelTraversable|'s
+    1. Let |site| be the result of running [=obtain a site=] given |origin|.
+    1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
         [=top-level traversable/bounce tracking record=]'s
         [=bounce tracking record/storage access set=].
 
@@ -437,9 +438,11 @@ To <dfn>process navigation start for bounce tracking</dfn> given a [=navigable=]
 |navigable| and [=Document=] |sourceDocument|, perform the following steps:
 
 1. If |navigable| is not a [=top-level traversable=], then abort these steps.
-1. Set |initialHost| to |sourceDocument|'s [=Document/origin=]'s [=host=] if
-    |sourceDocument|'s [=Document/origin=] is not an [=opaque origin=], and
-    empty string otherwise.
+1. Let |origin| be |sourceDocument|'s [=Document/origin=].
+1. If |origin| is an [=opaque origin=], set |initialHost| to empty string.
+1. Otherwise,
+    1. Let |site| be the result of running [=obtain a site=] given |origin|.
+    1. Set |initialHost| to |site|'s [=host=].
 1. Set |navigable|'s [=top-level traversable/bounce tracking record=] to a new
     [=bounce tracking record=] with [=bounce tracking record/initial host=]
     set to |initialHost|.
@@ -467,9 +470,11 @@ To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
 1. If |URLs| is empty, then abort these steps.
 1. Set |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s
     [=bounce tracking record/initial host=].
-1. Set |finalHost| to the [=host=] of the last entry in |URLs|.
+1. Let |finalSite| be the result of running [=obtain a site=] given the last entry in |URLs|.
+1. Set |finalHost| to the [=host=] of |finalSite|.
 1. [=map/For each=] |URL| in |URLs|:
-    1. Let |host| be the |URL|'s [=host=].
+    1. Let |site| be the result of running [=obtain a site=] given |URL|.
+    1. Let |host| be the |site|'s [=host=].
     1. If |host| matches |initialHost| or |finalHost|, skip this |URL|.
     1. If [=user activation map=] [=map/contains=] |host|, skip this |URL|.
     1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s

--- a/index.bs
+++ b/index.bs
@@ -493,7 +493,7 @@ To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
     1. If |host| [=host/equals=] |initialHost| or |finalHost|, [=iteration/continue=].
     1. If [=user activation map=] [=map/contains=] |host|, [=iteration/continue=].
     1. If |navigable|'s [=top-level traversable/bounce tracking record=]'s
-        [=bounce tracking record/storage access set=] [=set/contains=] |host|, [=iteration/continue=].
+        [=bounce tracking record/storage access set=] does not [=set/contain=] |host|, [=iteration/continue=].
     1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
         [=navigable/active document=].
     1. Set [=stateful bounce tracking map=][|host|] to |topDocument|'s

--- a/index.bs
+++ b/index.bs
@@ -437,8 +437,6 @@ Monkey Patch</h5>
 
 At the start of a navigation, initialize the [=bounce tracking record=].
 
-Each [=top-level traversable=] maintains a record of which sites it has saved cookies for.
-
 Insert the following steps in the <a spec="html">navigate</a> algorithm before
 step 8,
 "[Navigate to a fragment](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid) given navigable, url, historyHandling, and navigationId."

--- a/index.bs
+++ b/index.bs
@@ -15,6 +15,7 @@ Complain About: accidental-2119 yes, missing-example-ids yes
 Markup Shorthands: markdown yes, css no
 Assume Explicit For: yes
 Metadata Order: !*, *, This version
+
 !Participate: <a href="https://github.com/[REPOSITORY]">Github Repository</a>
 !Participate: <a href="https://github.com/privacycg/meetings/">Privacy CG Meetings</a>
 </pre>
@@ -38,7 +39,6 @@ Metadata Order: !*, *, This version
 <pre class="anchors">
 spec: HTTP; urlPrefix: https://httpwg.org/specs/rfc7231.html#
     type: dfn; text: HTTP 3xx statuses; url: status.3xx
-    type: dfn; text: bc-traversable; url: bc-traversable
 spec: tracking-dnt; urlPrefix: https://www.w3.org/TR/tracking-dnt/#
     type: dfn; text: tracking; url: dfn-tracking
 spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265/
@@ -303,12 +303,12 @@ the PrivacyCG.
 The user agent holds a <dfn>user activation map</dfn> which is a [=map=] of
 [=site=] [=hosts=] to [=moments=].  The [=moments=] represent the most recent
 [=wall clock=] time at which the user activated a top-level document on the
-associated [=host=].
+associated [=site=] [=host=].
 
 The user agent holds a <dfn>candidate bounce tracking map</dfn> which is a
 [=map=] of [=site=] [=hosts=] to [=moments=].  The [=moments=] represent the
 first [=wall clock=] time since the last execution of the
-[=bounce tracking timer=] at which a page on the given [=host=] performed
+[=bounce tracking timer=] at which a page on the given [=site=] [=host=] performed
 an action that could indicate bounce tracking took place.  For example,
 if [=bounce tracking timer=] ran at time X and bounces occurred at times X-1,
 X+1, and X+2, then the map value would be X+1.
@@ -325,16 +325,17 @@ the same time.  The maps will have non-overlapping sets of keys.
 
 Each [=top-level traversable=] has an associated
 <dfn for="top-level traversable">bounce tracking record</dfn> which is a
-[=bounce tracking record=] or null.  Initially it is null.
+[=bounce tracking record=] or null. This stores the data relevant
+to bounce tracking enforcement for every navigation. Initially it is null, and it becomes
+non-null when an [=bounce tracking record/initial host=] is detected.
 
-A <dfn>bounce tracking record</dfn> is a [=struct=].
-
-A [=bounce tracking record=] has an associated
-<dfn for="bounce tracking record">initial host</dfn>, a [=host=].
-
-A [=bounce tracking record=] has an associated
-<dfn for="bounce tracking record">storage access set</dfn> which is [=set=]
-of [=hosts=].
+A <dfn>bounce tracking record</dfn> is a [=struct=] whose items are:
+<dl dfn-for="bounce tracking record">
+<dt><dfn>initial host</dfn></dt>
+<dd>a [=site=]'s [=host=]</dd>
+<dt><dfn>storage access set</dfn></dt>
+<dd>a [=set=] of [=sites=]' [=hosts=]</dd>
+</dl>
 
 
 <h4 id="bounce-tracking-mitigations-data-model-constants">Constants</h4>
@@ -342,13 +343,13 @@ of [=hosts=].
 The <dfn>bounce tracking grace period</dfn> is an [=implementation-defined=]
 [=duration=] that represents the length of time after a possible bounce tracking
 event during which the user agent will wait for an interaction before deleting a
-[=host=]'s storage.
+[=site=] [=host=]'s storage.
 
 Note: 1 hour is a reasonable [=bounce tracking grace period=] value.
 
 The <dfn>bounce tracking activation lifetime</dfn> is an
 [=implementation-defined=] [=duration=] that represents how long user
-activations will protect a [=host=] from storage deletion.
+activations will protect a [=site=] [=host=] from storage deletion.
 
 Note: 45 days is a reasonable [=bounce tracking activation lifetime=] value.
 
@@ -397,6 +398,13 @@ Cookie Write Monkey Patch</h5>
 
 Each [=top-level traversable=] maintains a record of which sites it has saved cookies for.
 
+Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorithm after step 15,
+"... run the "set-cookie-string" parsing algorithm (see [section 5.2](https://httpwg.org/specs/rfc6265.html#set-cookie) of [[COOKIES]]) ...":
+
+1. If cookies were stored in the cookie store in the previous step, then
+    run [=process a network cookie access for bounce tracking mitigations=]
+    given <var ignore>request</var>.
+
 <div algorithm>
 
 To <dfn>process a network cookie access for bounce tracking mitigations</dfn>
@@ -407,7 +415,7 @@ given a [=request=] |request|, perform the following steps:
 1. If |request|'s [=request/destination=] is "`document`", then:
     1. Let |topLevelTraversable| be |request|'s [=request/client=]'s
         [=environment/target browsing context=]'s
-        [=bc-traversable|top-level traversable=].
+        [=browsing context/top-level traversable=].
     1. [=Assert=]: |topLevelTraversable|'s
         [=top-level traversable/bounce tracking record=] is not null.
     1. Let |site| be the result of running [=obtain a site=] given |origin|.
@@ -419,20 +427,24 @@ Issue: TODO: Handle subresource requests and iframes for client-side redirects.
 
 </div>
 
-Insert the following steps in the <a spec="fetch">HTTP-network fetch</a>
-algorithm after step 15 where cookies are parsed and saved in the cookie store:
-
-1. If cookies were stored in the cookie store in the previous step, then
-    run [=process a network cookie access for bounce tracking mitigations=]
-    given <var ignore>request</var>.
-
 Note: We currently don't treat cookie reads as stateful, but this would be a
-reasonable future change.We could run [=process a network cookie access for bounce tracking mitigations=]
-in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2 where cookies are
-added to the request headers.
+reasonable future change. We could run [=process a network cookie access for bounce tracking mitigations=]
+in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2,
+"... [=append=] (`Cookie`, cookies) to httpRequest’s [=header list=]. ..."
 
 <h5 id="bounce-tracking-mitigations-nav-start-monkey-patch">Start Navigation
 Monkey Patch</h5>
+
+At the start of a navigation, initialize the [=bounce tracking record=].
+
+Each [=top-level traversable=] maintains a record of which sites it has saved cookies for.
+
+Insert the following steps in the <a spec="html">navigate</a> algorithm before
+step 8,
+"[Navigate to a fragment](https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid) given navigable, url, historyHandling, and navigationId."
+
+1. Run [=process navigation start for bounce tracking=] given
+    <var ignore>navigable</var> and <var ignore>sourceDocument</var>.
 
 <div algorithm>
 
@@ -454,14 +466,15 @@ Issue: TODO: Handle programmatic navigations within a particular time frame as
 
 </div>
 
-Insert the following steps in the <a spec="html">navigate</a> algorithm before
-step 8 where navigation to fragments is handled.
-
-1. Run [=process navigation start for bounce tracking=] given
-    <var ignore>navigable</var> and <var ignore>sourceDocument</var>.
-
 <h5 id="bounce-tracking-mitigations-nav-end-monkey-patch">End Navigation Monkey
 Patch</h5>
+
+At the end of a navigation, fill the [=candidate bounce tracking map=].
+
+Insert the following steps in the <a spec="html">navigate</a> algorithm after Ending Navigation.
+
+1. Run [=process navigation end for bounce tracking=] given
+    <var ignore>navigable</var> and <var ignore>URLs</var>.
 
 <div algorithm>
 
@@ -477,8 +490,8 @@ To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
 1. [=map/For each=] |URL| in |URLs|:
     1. Let |site| be the result of running [=obtain a site=] given |URL|.
     1. Let |host| be the |site|'s [=host=].
-    1. If |host| matches |initialHost| or |finalHost|, skip this |URL|.
-    1. If [=user activation map=] [=map/contains=] |host|, skip this |URL|.
+    1. If |host| [=host/equals=] |initialHost| or |finalHost|, [=iteration/continue=].
+    1. If [=user activation map=] [=map/contains=] |host|, [=iteration/continue=].
     1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
         [=navigable/active document=].
     1. Set [=candidate bounce tracking map=][|host|] to |topDocument|'s
@@ -487,11 +500,6 @@ To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
 Issue: TODO: Include potential client-side redirects, and detection timer logic.
 
 </div>
-
-Insert the following steps in the <a spec="html">navigate</a> algorithm after Ending Navigation.
-
-1. Run [=process navigation end for bounce tracking=] given
-    <var ignore>navigable</var> and <var ignore>URLs</var>.
 
 <h4 id="bounce-tracking-mitigations-timer">Timer</h4>
 

--- a/index.bs
+++ b/index.bs
@@ -392,6 +392,9 @@ model]]:
 <h4 id="bounce-tracking-mitigation-stateful-bounce-detection">Stateful Bounce
 Detection</h4>
 
+<h5 id="bounce-tracking-mitigations-network-cookie-write-monkey-patch">Network
+Cookie Write Monkey Patch</h5>
+
 <div algorithm>
 
 To <dfn>process a network cookie access for bounce tracking mitigations</dfn>
@@ -413,9 +416,6 @@ Issue: TODO: Handle subresource requests and iframes for client-side redirects.
 
 </div>
 
-<h5 id="bounce-tracking-mitigations-network-cookie-write-monkey-patch">Network
-Cookie Write Monkey Patch</h5>
-
 Insert the following steps in the <a spec="fetch">HTTP-network fetch</a>
 algorithm after step 15 where cookies are parsed and saved in the cookie store:
 
@@ -423,15 +423,10 @@ algorithm after step 15 where cookies are parsed and saved in the cookie store:
     run [=process a network cookie access for bounce tracking mitigations=]
     given <var ignore>request</var>.
 
-<h5 id="bounce-tracking-mitigations-network-cookie-read-monkey-patch">Network
-Cookie Read Monkey Patch</h5>
-
-Insert the following steps in the <a spec="fetch">HTTP-network-or-cache fetch</a>
-algorithm after step 8.21.1.2 where cookies are added to the request headers:
-
-1. If cookies were attached to the request in the previous step, then run
-    [=process a network cookie access for bounce tracking mitigations=] given
-    <var ignore>httpRequest</var>.
+Note: We currently don't treat cookie reads as stateful, but this would be a
+reasonable future change.We could run [=process a network cookie access for bounce tracking mitigations=]
+in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2 where cookies are
+added to the request headers.
 
 <h5 id="bounce-tracking-mitigations-nav-start-monkey-patch">Start Navigation
 Monkey Patch</h5>
@@ -476,6 +471,7 @@ To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
 1. [=map/For each=] |URL| in |URLs|:
     1. Let |host| be the |URL|'s [=host=].
     1. If |host| matches |initialHost| or |finalHost|, skip this |URL|.
+    1. If [=user activation map=] [=map/contains=] |host|, skip this |URL|.
     1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
         [=navigable/active document=].
     1. Set [=candidate bounce tracking map=][|host|] to |topDocument|'s

--- a/index.bs
+++ b/index.bs
@@ -395,6 +395,8 @@ Detection</h4>
 <h5 id="bounce-tracking-mitigations-network-cookie-write-monkey-patch">Network
 Cookie Write Monkey Patch</h5>
 
+Each [=top-level traversable=] maintains a record of which sites it has saved cookies for.
+
 <div algorithm>
 
 To <dfn>process a network cookie access for bounce tracking mitigations</dfn>

--- a/index.bs
+++ b/index.bs
@@ -15,7 +15,6 @@ Complain About: accidental-2119 yes, missing-example-ids yes
 Markup Shorthands: markdown yes, css no
 Assume Explicit For: yes
 Metadata Order: !*, *, This version
-
 !Participate: <a href="https://github.com/[REPOSITORY]">Github Repository</a>
 !Participate: <a href="https://github.com/privacycg/meetings/">Privacy CG Meetings</a>
 </pre>
@@ -39,6 +38,7 @@ Metadata Order: !*, *, This version
 <pre class="anchors">
 spec: HTTP; urlPrefix: https://httpwg.org/specs/rfc7231.html#
     type: dfn; text: HTTP 3xx statuses; url: status.3xx
+    type: dfn; text: bc-traversable; url: bc-traversable
 spec: tracking-dnt; urlPrefix: https://www.w3.org/TR/tracking-dnt/#
     type: dfn; text: tracking; url: dfn-tracking
 spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265/
@@ -298,6 +298,8 @@ the PrivacyCG.
 
 <h3 id="bounce-tracking-mitigations-data-model">Data Model</h3>
 
+<h4 id="bounce-tracking-mitigations-data-model-global">Global Data</h4>
+
 The user agent holds a <dfn>user activation map</dfn> which is a [=map=] of
 [=site=] [=hosts=] to [=moments=].  The [=moments=] represent the most recent
 [=wall clock=] time at which the user activated a top-level document on the
@@ -319,6 +321,24 @@ a user activation occurs.  This means that a given host can exist in either the
 [=user activation map=] or [=candidate bounce tracking map=], but not both at
 the same time.  The maps will have non-overlapping sets of keys.
 
+<h4 id="bounce-tracking-mitigations-data-model-per-tab">Per-Tab Data</h4>
+
+Each [=top-level traversable=] has an associated
+<dfn for="top-level traversable">bounce tracking record</dfn> which is a
+[=bounce tracking record=] or null.  Initially it is null.
+
+A <dfn>bounce tracking record</dfn> is a [=struct=].
+
+A [=bounce tracking record=] has an associated
+<dfn for="bounce tracking record">initial host</dfn>, a [=host=].
+
+A [=bounce tracking record=] has an associated
+<dfn for="bounce tracking record">storage access set</dfn> which is [=set=]
+of [=hosts=].
+
+
+<h4 id="bounce-tracking-mitigations-data-model-constants">Constants</h4>
+
 The <dfn>bounce tracking grace period</dfn> is an [=implementation-defined=]
 [=duration=] that represents the length of time after a possible bounce tracking
 event during which the user agent will wait for an interaction before deleting a
@@ -339,8 +359,6 @@ algorithm.
 Note: 1 hour is a reasonable [=bounce tracking timer period=] value.
 
 <h3 id="bounce-tracking-mitigations-algorithms">Algorithms</h3>
-
-* TODO: Define the steps necessary to detect and store a "bounce".
 
 <h4 id="bounce-tracking-mitigations-activation-monkey-patch">User Activation
 Monkey Patch</h4>
@@ -371,13 +389,113 @@ model]]:
 
 1. Run [=record a user activation=] given <var ignore>document</var>.
 
+<h4 id="bounce-tracking-mitigation-stateful-bounce-detection">Stateful Bounce
+Detection</h4>
+
+<div algorithm>
+
+To <dfn>process a network cookie access for bounce tracking mitigations</dfn>
+given a [=request=] |request|, perform the following steps:
+
+1. Let |origin| be |request|'s [=request/origin=].
+1. If |origin| is an [=opaque origin=], then abort these steps.
+1. If |request|'s [=request/destination=] is "`document`", then:
+    1. Let |topLevelTraversable| be |request|'s [=request/client=]'s
+        [=environment/target browsing context=]'s
+        [=bc-traversable|top-level traversable=].
+    1. [=Assert=]: |topLevelTraversable|'s
+        [=top-level traversable/bounce tracking record=] is not null.
+    1. [=set/Append=] |origin|'s [=host=] to |topLevelTraversable|'s
+        [=top-level traversable/bounce tracking record=]'s
+        [=bounce tracking record/storage access set=].
+
+Issue: TODO: Handle subresource requests and iframes for client-side redirects.
+
+</div>
+
+<h5 id="bounce-tracking-mitigations-network-cookie-write-monkey-patch">Network
+Cookie Write Monkey Patch</h5>
+
+Insert the following steps in the <a spec="fetch">HTTP-network fetch</a>
+algorithm after step 15 where cookies are parsed and saved in the cookie store:
+
+1. If cookies were stored in the cookie store in the previous step, then
+    run [=process a network cookie access for bounce tracking mitigations=]
+    given <var ignore>request</var>.
+
+<h5 id="bounce-tracking-mitigations-network-cookie-read-monkey-patch">Network
+Cookie Read Monkey Patch</h5>
+
+Insert the following steps in the <a spec="fetch">HTTP-network-or-cache fetch</a>
+algorithm after step 8.21.1.2 where cookies are added to the request headers:
+
+1. If cookies were attached to the request in the previous step, then run
+    [=process a network cookie access for bounce tracking mitigations=] given
+    <var ignore>httpRequest</var>.
+
+<h5 id="bounce-tracking-mitigations-nav-start-monkey-patch">Start Navigation
+Monkey Patch</h5>
+
+<div algorithm>
+
+To <dfn>process navigation start for bounce tracking</dfn> given a [=navigable=]
+|navigable| and [=Document=] |sourceDocument|, perform the following steps:
+
+1. If |navigable| is not a [=top-level traversable=], then abort these steps.
+1. Set |initialHost| to |sourceDocument|'s [=Document/origin=]'s [=host=] if
+    |sourceDocument|'s [=Document/origin=] is not an [=opaque origin=], and
+    empty string otherwise.
+1. Set |navigable|'s [=top-level traversable/bounce tracking record=] to a new
+    [=bounce tracking record=] with [=bounce tracking record/initial host=]
+    set to |initialHost|.
+
+Issue: TODO: Handle programmatic navigations within a particular time frame as
+    client-side redirects.
+
+</div>
+
+Insert the following steps in the <a spec="html">navigate</a> algorithm before
+step 8 where navigation to fragments is handled.
+
+1. Run [=process navigation start for bounce tracking=] given
+    <var ignore>navigable</var> and <var ignore>sourceDocument</var>.
+
+<h5 id="bounce-tracking-mitigations-nav-end-monkey-patch">End Navigation Monkey
+Patch</h5>
+
+<div algorithm>
+
+To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
+|navigable| and [=response/url list=] |URLs|, perform the following steps:
+
+1. If |navigable| is not a [=top-level traversable=], then abort these steps.
+1. If |URLs| is empty, then abort these steps.
+1. Set |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s
+    [=bounce tracking record/initial host=].
+1. Set |finalHost| to the [=host=] of the last entry in |URLs|.
+1. [=map/For each=] |URL| in |URLs|:
+    1. Let |host| be the |URL|'s [=host=].
+    1. If |host| matches |initialHost| or |finalHost|, skip this |URL|.
+    1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
+        [=navigable/active document=].
+    1. Set [=candidate bounce tracking map=][|host|] to |topDocument|'s
+        [=relevant settings object=]'s [=environment settings object/current wall time=].
+
+Issue: TODO: Include potential client-side redirects, and detection timer logic.
+
+</div>
+
+Insert the following steps in the <a spec="html">navigate</a> algorithm after Ending Navigation.
+
+1. Run [=process navigation end for bounce tracking=] given
+    <var ignore>navigable</var> and <var ignore>URLs</var>.
+
 <h4 id="bounce-tracking-mitigations-timer">Timer</h4>
 
 <div algorithm>
 
 To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
-[=wall clock=] |now|,
-perform the following steps:
+[=wall clock=] |now|, perform the following steps:
 
 1. [=map/For each=] |host| -> |activationTime| of [=user activation map=]:
     1. [=Assert=] that [=candidate bounce tracking map=] does not
@@ -423,9 +541,6 @@ following steps:
     1. Remove |cookie| from the [=cookie store=].
 
 </div>
-
-Issue: TODO: Verify that using [=domain-match=] catches all cookies for the
-    [=host/registrable domain=].
 
 <div algorithm>
 To <dfn>clear non-cookie storage for host</dfn> given a [=host=] |host|, perform

--- a/index.bs
+++ b/index.bs
@@ -305,20 +305,20 @@ The user agent holds a <dfn>user activation map</dfn> which is a [=map=] of
 [=wall clock=] time at which the user activated a top-level document on the
 associated [=site=] [=host=].
 
-The user agent holds a <dfn>candidate bounce tracking map</dfn> which is a
+The user agent holds a <dfn>stateful bounce tracking map</dfn> which is a
 [=map=] of [=site=] [=hosts=] to [=moments=].  The [=moments=] represent the
 first [=wall clock=] time since the last execution of the
 [=bounce tracking timer=] at which a page on the given [=site=] [=host=] performed
-an action that could indicate bounce tracking took place.  For example,
+an action that could indicate stateful bounce tracking took place.  For example,
 if [=bounce tracking timer=] ran at time X and bounces occurred at times X-1,
 X+1, and X+2, then the map value would be X+1.
 
 Note: Schemeless site is used as the data structure key because by default cookies
 are sent to both `http://` and `https://` pages on the same domain.
 
-Note: Hosts are eagerly removed from the [=candidate bounce tracking map=] when
+Note: Hosts are eagerly removed from the [=stateful bounce tracking map=] when
 a user activation occurs.  This means that a given host can exist in either the
-[=user activation map=] or [=candidate bounce tracking map=], but not both at
+[=user activation map=] or [=stateful bounce tracking map=], but not both at
 the same time.  The maps will have non-overlapping sets of keys.
 
 <h4 id="bounce-tracking-mitigations-data-model-per-tab">Per-Tab Data</h4>
@@ -377,7 +377,7 @@ the following steps:
 1. If |origin| is an [=opaque origin=] then abort these steps.
 1. Let |site| be the result of running [=obtain a site=] given |origin|.
 1. Let |host| be |site|'s [=host=].
-1. [=map/Remove=] |host| from the [=candidate bounce tracking map=].
+1. [=map/Remove=] |host| from the [=stateful bounce tracking map=].
 1. Set [=user activation map=][|host|] to |topDocument|'s
     [=relevant settings object=]'s
     [=environment settings object/current wall time=].
@@ -469,7 +469,7 @@ Issue: TODO: Handle programmatic navigations within a particular time frame as
 <h5 id="bounce-tracking-mitigations-nav-end-monkey-patch">End Navigation Monkey
 Patch</h5>
 
-At the end of a navigation, fill the [=candidate bounce tracking map=].
+At the end of a navigation, fill the [=stateful bounce tracking map=].
 
 Insert the following steps in the <a spec="html">navigate</a> algorithm after Ending Navigation.
 
@@ -492,9 +492,11 @@ To <dfn>process navigation end for bounce tracking</dfn> given a [=navigable=]
     1. Let |host| be the |site|'s [=host=].
     1. If |host| [=host/equals=] |initialHost| or |finalHost|, [=iteration/continue=].
     1. If [=user activation map=] [=map/contains=] |host|, [=iteration/continue=].
+    1. If |navigable|'s [=top-level traversable/bounce tracking record=]'s
+        [=bounce tracking record/storage access set=] [=set/contains=] |host|, [=iteration/continue=].
     1. Let |topDocument| be |navigable|'s [=top-level traversable=]'s
         [=navigable/active document=].
-    1. Set [=candidate bounce tracking map=][|host|] to |topDocument|'s
+    1. Set [=stateful bounce tracking map=][|host|] to |topDocument|'s
         [=relevant settings object=]'s [=environment settings object/current wall time=].
 
 Issue: TODO: Include potential client-side redirects, and detection timer logic.
@@ -509,11 +511,11 @@ To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
 [=wall clock=] |now|, perform the following steps:
 
 1. [=map/For each=] |host| -> |activationTime| of [=user activation map=]:
-    1. [=Assert=] that [=candidate bounce tracking map=] does not
+    1. [=Assert=] that [=stateful bounce tracking map=] does not
         [=map/contain=] |host|.
     1. If |activationTime| + [=bounce tracking activation lifetime=] is before
         |now|, then [=map/remove=] |host| from [=user activation map=].
-1. [=map/For each=] |host| -> |bounceTime| of [=candidate bounce tracking map=]:
+1. [=map/For each=] |host| -> |bounceTime| of [=stateful bounce tracking map=]:
     1. [=Assert=] that [=user activation map=] does not [=map/contain=] |host|.
     1. If |bounceTime| + [=bounce tracking grace period=] is after |now|, then
         [=iteration/continue=].
@@ -521,7 +523,7 @@ To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
         [=navigable/active document=]'s [=Document/origin=]'s
         [=obtain a site|site=]'s [=host=] equals |host|,
         then [=iteration/continue=].
-    1. [=map/Remove=] |host| from [=candidate bounce tracking map=].
+    1. [=map/Remove=] |host| from [=stateful bounce tracking map=].
     1. [=Clear cookies for host=] given |host|.
     1. [=Clear non-cookie storage for host=] given |host|.
     1. [=Clear cache for host=] given |host|.

--- a/index.bs
+++ b/index.bs
@@ -542,6 +542,9 @@ following steps:
 
 </div>
 
+Issue: TODO: Verify that using [=domain-match=] catches all cookies for the
+    [=host/registrable domain=].
+
 <div algorithm>
 To <dfn>clear non-cookie storage for host</dfn> given a [=host=] |host|, perform
 the following steps:


### PR DESCRIPTION
Building off of wanderview@'s WIP PR that defines navigation start, and doing the same for navigation end.

I think that these are all the steps needed to account for server redirects. Our code adds logic around redirect chaining, committed/uncommitted redirects, and stateful/stateless bounces. But AFAICT these are only for metrics or experimental features.

In a future PR I'll include client-side redirect detection. These should be able to reuse the same hooks for navigation start/end.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/45.html" title="Last updated on May 24, 2023, 6:14 PM UTC (0880362)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/45/6c9918a...amaliev:0880362.html" title="Last updated on May 24, 2023, 6:14 PM UTC (0880362)">Diff</a>