### PR TITLE
Start/end nav flows with client redirects

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -464,14 +464,14 @@ given a [=request=] |request|, perform the following steps:
 1. Let |origin| be |request|'s [=request/origin=].
 1. If |origin| is an [=opaque origin=], then abort these steps.
 1. If |request|'s [=request/destination=] is "`document`", then:
-    1. [=Assert=]: |request|'s [=request/client=] is not null, and
+    1. If |request|'s [=request/client=] is null, or
         |request|'s [=request/client=]'s [=environment/target browsing context=]
-        is not null.
+        is null, then abort these steps.
     1. Let |topLevelTraversable| be |request|'s [=request/client=]'s
         [=environment/target browsing context=]'s
         [=browsing context/top-level traversable=].
-    1. [=Assert=]: |topLevelTraversable|'s
-        [=top-level traversable/bounce tracking record=] is not null.
+    1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]
+        is null, abort these steps.
     1. Let |site| be the result of running [=obtain a site=] given |origin|.
     1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
         [=top-level traversable/bounce tracking record=]'s


### PR DESCRIPTION
Patching https://github.com/privacycg/nav-tracking-mitigations/pull/45 with support for client redirects

This adds:
- Global tracking for initial host, final host, and bounce set, to build the redirect chain correctly
- Client bounce detection timer logic
- Differentiation between committed and committed redirects, to update the final host correctly


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/46.html" title="Last updated on Jun 5, 2023, 4:18 PM UTC (6f0b402)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/46/6c9918a...amaliev:6f0b402.html" title="Last updated on Jun 5, 2023, 4:18 PM UTC (6f0b402)">Diff</a>