### PR TITLE
Monkey patch for non-cookie storage access

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -477,8 +477,6 @@ given a [=request=] |request|, perform the following steps:
         [=top-level traversable/bounce tracking record=]'s
         [=bounce tracking record/storage access set=].
 
-Issue: TODO: Handle subresource requests and iframes for client-side redirects.
-
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a

--- a/index.bs
+++ b/index.bs
@@ -477,12 +477,44 @@ given a [=request=] |request|, perform the following steps:
         [=top-level traversable/bounce tracking record=]'s
         [=bounce tracking record/storage access set=].
 
+Issue: TODO: Handle subresource requests and iframes for client-side redirects.
+
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a
 reasonable future change. We could run [=process a network cookie access for bounce tracking mitigations=]
 in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2,
 "... [=append=] (`Cookie`, cookies) to httpRequest’s [=header list=]. ..."
+
+<h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
+
+Each [=top-level traversable=] maintains a record of which sites have accessed storage in the current [=extended navigation=].
+
+Insert the following steps in the <a spec="storage">obtain a storage key</a> algorithm before step 4, "Return key":
+
+1. Run [=process a storage access for bounce tracking mitigations=] given <var ignore>environment</var>.
+
+Issue: TODO: Verify that this algorithm is the correct location to catch precisely those sites which access non-cookie storage.
+
+<div algorithm>
+
+To <dfn>process a storage access for bounce tracking mitigations</dfn>
+given an [=environment=] |environment|, perform the following steps:
+
+
+1. Let |origin| be |environment|'s [=environment/top-level origin=].
+1. If |origin| is null or an [=opaque origin=], then abort these steps.
+1. Let |browsingContext| be |environment|'s [=environment/target browsing context=].
+1. If |browsingContext| is null, then abort these steps.
+1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
+1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null,
+    then abort these steps.
+1. Let |site| be the result of running [=obtain a site=] given |origin|.
+1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
+        [=top-level traversable/bounce tracking record=]'s
+        [=bounce tracking record/storage access set=].
+
+</div>
 
 <h5 id="bounce-tracking-mitigations-response-received-monkey-patch">Response Received Monkey
 Patch</h5>


### PR DESCRIPTION
We still need to confirm that "obtain a storage key" and its neighbors are the correct place to patch, which I will follow up on in a WHATWG issue. Pushing this as a description of the algorithm's behavior, while the Storage spec patch location is being finalized.