### PR TITLE
Specify client for subresource/non-subresource requests.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -486,6 +486,32 @@ reasonable future change. We could run [=process a network cookie access for bou
 in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2,
 "... [=append=] (`Cookie`, cookies) to httpRequest’s [=header list=]. ..."
 
+<h5 id="bounce-tracking-mitigations-service-worker-activation-monkey-patch">Service Worker Activation Monkey Patch</h5>
+
+Each [=top-level traversable=] maintains a record of which sites have activated service workers in the current [=extended navigation=].
+
+Insert the following steps in the [activate]((https://w3c.github.io/ServiceWorker/#activate) algorithm before step 11,
+"Run the [Update Worker State](https://w3c.github.io/ServiceWorker/#update-worker-state) algorithm...":
+
+1. Run [=process a service worker activation for bounce tracking mitigations=] given <var ignore>registration</var> and <var ignore>matchedClients</var>.
+
+<div algorithm>
+
+To <dfn>process a service worker activation for bounce tracking mitigations</dfn>
+given a [=service worker registration=] |registration| and a list of [=service worker clients=] |matchedClients|,
+perform the following steps:
+
+1. Let |host| be |registration|'s [=service worker registration/scope url=]'s [=host=].
+1. [=list/For each=] |client| in |matchedClients|:
+    1. Let |browsingContext| be |client|'s [=environment/target browsing context=].
+    1. If |browsingContext| is null, then [=iteration/continue=].
+    1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
+    1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null, then [=iteration/continue=].
+    1. [=set/Append=] |host| to |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]'s
+        [=bounce tracking record/storage access set=].
+
+</div>
+
 <h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
 
 Each [=top-level traversable=] maintains a record of which sites have accessed storage in the current [=extended navigation=].
@@ -503,6 +529,11 @@ So this patch is not comprehensive.</p>
 To <dfn>process a storage access for bounce tracking mitigations</dfn>
 given an [=environment=] |environment|, perform the following steps:
 
+1. If |environment| is not an [=environment settings object=], then abort these steps.
+
+Note: At time of writing, <a spec="storage">obtain a storage bottle map</a> can only accept an [=environment settings object=] |environment|,
+but this will be refactored to support [=service workers=] which attempt to access storage on every navigation, and thus is not considered
+when updating the [=bounce tracking record/storage access set=].
 
 1. Let |origin| be |environment|'s [=environment/top-level origin=].
 1. If |origin| is null or an [=opaque origin=], then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -464,10 +464,10 @@ given a [=request=] |request|, perform the following steps:
 1. Let |origin| be |request|'s [=request/origin=].
 1. If |origin| is an [=opaque origin=], then abort these steps.
 1. If |request|'s [=request/destination=] is "`document`", then:
-    1. If |request|'s [=request/client=] is null, or
-        |request|'s [=request/client=]'s [=environment/target browsing context=]
+    1. If |request|'s [=request/reserved client=] is null, or
+        |request|'s [=request/reserved client=]'s [=environment/target browsing context=]
         is null, then abort these steps.
-    1. Let |topLevelTraversable| be |request|'s [=request/client=]'s
+    1. Let |topLevelTraversable| be |request|'s [=request/reserved client=]'s
         [=environment/target browsing context=]'s
         [=browsing context/top-level traversable=].
     1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]

--- a/index.bs
+++ b/index.bs
@@ -477,8 +477,6 @@ given a [=request=] |request|, perform the following steps:
         [=top-level traversable/bounce tracking record=]'s
         [=bounce tracking record/storage access set=].
 
-Issue: TODO: Handle subresource requests and iframes for client-side redirects.
-
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a

--- a/index.bs
+++ b/index.bs
@@ -520,7 +520,7 @@ Insert the following steps in the <a spec="storage">obtain a storage bottle map<
 
 1. Run [=process a storage access for bounce tracking mitigations=] given <var ignore>environment</var>.
 
-<p class=note>[Note](https://whatwg/storage#165): This patch has to be run whenever a site accesses non-cookie storage.
+Issue(whatwg/storage#165): This patch has to be run whenever a site accesses non-cookie storage.
 <a spec="storage">Obtain a storage bottle map</a> is the intended hook for this, but it does not currently have full coverage across specs that use storage.
 So this patch is not comprehensive.</p>
 

--- a/index.bs
+++ b/index.bs
@@ -490,11 +490,13 @@ in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21
 
 Each [=top-level traversable=] maintains a record of which sites have accessed storage in the current [=extended navigation=].
 
-Insert the following steps in the <a spec="storage">obtain a storage key</a> algorithm before step 4, "Return key":
+Insert the following steps in the <a spec="storage">obtain a storage bottle map</a> algorithm before step 10, "Return <var ignore>proxyMap</var>":
 
 1. Run [=process a storage access for bounce tracking mitigations=] given <var ignore>environment</var>.
 
-Issue: TODO: Verify that this algorithm is the correct location to catch precisely those sites which access non-cookie storage.
+<p class=note>[Note](https://whatwg/storage#165): This patch has to be run whenever a site accesses non-cookie storage.
+<a spec="storage">Obtain a storage bottle map</a> is the intended hook for this, but it does not currently have full coverage across specs that use storage.
+So this patch is not comprehensive.</p>
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -453,12 +453,12 @@ Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorit
 "... run the "set-cookie-string" parsing algorithm (see [section 5.2](https://httpwg.org/specs/rfc6265.html#set-cookie) of [[COOKIES]]) ...":
 
 1. If cookies were stored in the cookie store in the previous step, then
-    run [=process a network cookie access for bounce tracking mitigations=]
+    run [=process a navigation storage access for bounce tracking mitigations=]
     given <var ignore>request</var>.
 
 <div algorithm>
 
-To <dfn>process a network cookie access for bounce tracking mitigations</dfn>
+To <dfn>process a navigation storage access for bounce tracking mitigations</dfn>
 given a [=request=] |request|, perform the following steps:
 
 1. Let |origin| be |request|'s [=request/origin=].
@@ -482,7 +482,7 @@ Issue: TODO: Handle subresource requests and iframes for client-side redirects.
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a
-reasonable future change. We could run [=process a network cookie access for bounce tracking mitigations=]
+reasonable future change. We could run [=process a navigation storage access for bounce tracking mitigations=]
 in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2,
 "... [=append=] (`Cookie`, cookies) to httpRequest’s [=header list=]. ..."
 
@@ -490,27 +490,10 @@ in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21
 
 Each [=top-level traversable=] maintains a record of which sites have activated service workers in the current [=extended navigation=].
 
-Insert the following steps in the [activate]((https://w3c.github.io/ServiceWorker/#activate) algorithm before step 11,
-"Run the [Update Worker State](https://w3c.github.io/ServiceWorker/#update-worker-state) algorithm...":
+Insert the following steps in the [Handle Fetch](https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm) algorithm after step 23,
+"If the result of running the [Run Service Worker](https://w3c.github.io/ServiceWorker/#run-service-worker) algorithm...":
 
-1. Run [=process a service worker activation for bounce tracking mitigations=] given <var ignore>registration</var> and <var ignore>matchedClients</var>.
-
-<div algorithm>
-
-To <dfn>process a service worker activation for bounce tracking mitigations</dfn>
-given a [=service worker registration=] |registration| and a list of [=service worker clients=] |matchedClients|,
-perform the following steps:
-
-1. Let |host| be |registration|'s [=service worker registration/scope url=]'s [=host=].
-1. [=list/For each=] |client| in |matchedClients|:
-    1. Let |browsingContext| be |client|'s [=environment/target browsing context=].
-    1. If |browsingContext| is null, then [=iteration/continue=].
-    1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
-    1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null, then [=iteration/continue=].
-    1. [=set/Append=] |host| to |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]'s
-        [=bounce tracking record/storage access set=].
-
-</div>
+1. Run [=process a navigation storage access for bounce tracking mitigations=] given <var ignore>request</var>.
 
 <h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
 
@@ -518,7 +501,7 @@ Each [=top-level traversable=] maintains a record of which sites have accessed s
 
 Insert the following steps in the <a spec="storage">obtain a storage bottle map</a> algorithm before step 10, "Return <var ignore>proxyMap</var>":
 
-1. Run [=process a storage access for bounce tracking mitigations=] given <var ignore>environment</var>.
+1. Run [=process a general storage access for bounce tracking mitigations=] given <var ignore>environment</var>.
 
 Issue(whatwg/storage#165): This patch has to be run whenever a site accesses non-cookie storage.
 <a spec="storage">Obtain a storage bottle map</a> is the intended hook for this, but it does not currently have full coverage across specs that use storage.
@@ -526,7 +509,7 @@ So this patch is not comprehensive.</p>
 
 <div algorithm>
 
-To <dfn>process a storage access for bounce tracking mitigations</dfn>
+To <dfn>process a general storage access for bounce tracking mitigations</dfn>
 given an [=environment=] |environment|, perform the following steps:
 
 1. If |environment| is not an [=environment settings object=], then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -453,12 +453,12 @@ Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorit
 "... run the "set-cookie-string" parsing algorithm (see [section 5.2](https://httpwg.org/specs/rfc6265.html#set-cookie) of [[COOKIES]]) ...":
 
 1. If cookies were stored in the cookie store in the previous step, then
-    run [=process a navigation storage access for bounce tracking mitigations=]
+    run [=process a fetch storage access for bounce tracking mitigations=]
     given <var ignore>request</var>.
 
 <div algorithm>
 
-To <dfn>process a navigation storage access for bounce tracking mitigations</dfn>
+To <dfn>process a fetch storage access for bounce tracking mitigations</dfn>
 given a [=request=] |request|, perform the following steps:
 
 1. Let |origin| be |request|'s [=request/origin=].
@@ -489,7 +489,7 @@ Issue: TODO: Handle iframes for client-side redirects.
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a
-reasonable future change. We could run [=process a navigation storage access for bounce tracking mitigations=]
+reasonable future change. We could run [=process a fetch storage access for bounce tracking mitigations=]
 in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2,
 "... [=append=] (`Cookie`, cookies) to httpRequest’s [=header list=]. ..."
 
@@ -500,7 +500,7 @@ Each [=top-level traversable=] maintains a record of which sites have activated 
 Insert the following steps in the [Handle Fetch](https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm) algorithm after step 23,
 "If the result of running the [Run Service Worker](https://w3c.github.io/ServiceWorker/#run-service-worker) algorithm...":
 
-1. Run [=process a navigation storage access for bounce tracking mitigations=] given <var ignore>request</var>.
+1. Run [=process a fetch storage access for bounce tracking mitigations=] given <var ignore>request</var>.
 
 <h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
 

--- a/index.bs
+++ b/index.bs
@@ -463,21 +463,28 @@ given a [=request=] |request|, perform the following steps:
 
 1. Let |origin| be |request|'s [=request/origin=].
 1. If |origin| is an [=opaque origin=], then abort these steps.
-1. If |request|'s [=request/destination=] is "`document`", then:
+1. If |request| is a [=subresource request=], then:
+    1. If |request|'s [=request/client=] is null, or
+        |request|'s [=request/client=]'s [=environment/target browsing context=]
+        is null, then abort these steps.
+    1. Let |topLevelTraversable| be |request|'s [=request/client=]'s
+        [=environment/target browsing context=]'s
+        [=browsing context/top-level traversable=].
+1. Otherwise,
     1. If |request|'s [=request/reserved client=] is null, or
         |request|'s [=request/reserved client=]'s [=environment/target browsing context=]
         is null, then abort these steps.
     1. Let |topLevelTraversable| be |request|'s [=request/reserved client=]'s
         [=environment/target browsing context=]'s
         [=browsing context/top-level traversable=].
-    1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]
-        is null, abort these steps.
-    1. Let |site| be the result of running [=obtain a site=] given |origin|.
-    1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
-        [=top-level traversable/bounce tracking record=]'s
-        [=bounce tracking record/storage access set=].
+1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]
+    is null, abort these steps.
+1. Let |site| be the result of running [=obtain a site=] given |origin|.
+1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
+    [=top-level traversable/bounce tracking record=]'s
+    [=bounce tracking record/storage access set=].
 
-Issue: TODO: Handle subresource requests and iframes for client-side redirects.
+Issue: TODO: Handle iframes for client-side redirects.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -477,12 +477,44 @@ given a [=request=] |request|, perform the following steps:
         [=top-level traversable/bounce tracking record=]'s
         [=bounce tracking record/storage access set=].
 
+Issue: TODO: Handle subresource requests and iframes for client-side redirects.
+
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a
 reasonable future change. We could run [=process a network cookie access for bounce tracking mitigations=]
 in the <a spec="fetch">HTTP-network-or-cache fetch</a> algorithm after step 8.21.1.2,
 "... [=append=] (`Cookie`, cookies) to httpRequest’s [=header list=]. ..."
+
+<h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
+
+Each [=top-level traversable=] maintains a record of which sites have accessed storage in the current [=extended navigation=].
+
+Insert the following steps in the <a spec="storage">obtain a storage key</a> algorithm before step 4, "Return key":
+
+1. Run [=process a storage access for bounce tracking mitigations=] given <var ignore>environment</var>.
+
+Issue: TODO: Verify that this algorithm is the correct location to catch precisely those sites which access non-cookie storage.
+
+<div algorithm>
+
+To <dfn>process a storage access for bounce tracking mitigations</dfn>
+given an [=environment=] |environment|, perform the following steps:
+
+
+1. Let |origin| be |environment|'s [=environment/top-level origin=].
+1. If |origin| is null or an [=opaque origin=], then abort these steps.
+1. Let |browsingContext| be |environment|'s [=environment/target browsing context=].
+1. If |browsingContext| is null, then abort these steps.
+1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
+1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null,
+    then abort these steps.
+1. Let |site| be the result of running [=obtain a site=] given |origin|.
+1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
+        [=top-level traversable/bounce tracking record=]'s
+        [=bounce tracking record/storage access set=].
+
+</div>
 
 <h5 id="bounce-tracking-mitigations-response-received-monkey-patch">Response Received Monkey
 Patch</h5>


### PR DESCRIPTION
As discussed offline, when handling a storage access during navigation, which client to check depends on whether the request is for a subresource (image, script, etc.) or not (document, iframe, etc.)

@wanderview


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/48.html" title="Last updated on Jun 9, 2023, 7:33 PM UTC (268bdd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/48/bec418a...amaliev:268bdd9.html" title="Last updated on Jun 9, 2023, 7:33 PM UTC (268bdd9)">Diff</a>