### PR TITLE
Iframe and CHIPS storage access

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -477,6 +477,9 @@ given a [=request=] |request|, perform the following steps:
     1. Let |topLevelTraversable| be |request|'s [=request/reserved client=]'s
         [=environment/target browsing context=]'s
         [=browsing context/top-level traversable=].
+    1. If |request|'s [=request/destination=] is "`iframe`", then:
+        1. Let |firstPartyOrigin| be |topLevelTraversable|'s [=navigable/active document=]'s [=Document/origin=].
+        1. If |origin| and |firstPartyOrigin| are not [=same site=], then abort these steps.
 1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]
     is null, abort these steps.
 1. Let |site| be the result of running [=obtain a site=] given |origin|.
@@ -525,11 +528,14 @@ Note: At time of writing, <a spec="storage">obtain a storage bottle map</a> can 
 but this will be refactored to support [=service workers=] which attempt to access storage on every navigation, and thus is not considered
 when updating the [=bounce tracking record/storage access set=].
 
-1. Let |origin| be |environment|'s [=environment/top-level origin=].
-1. If |origin| is null or an [=opaque origin=], then abort these steps.
 1. Let |browsingContext| be |environment|'s [=environment/target browsing context=].
 1. If |browsingContext| is null, then abort these steps.
+1. Let |activeDocument| be |browsingContext|'s active document.
+1. Let |origin| be |activeDocument|'s [=Document/origin=].
 1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
+1. If |activeDocument|'s node navigable's [=navigable/parent=] is non-null:
+    1. Let |firstPartyOrigin| be |topLevelTraversable|'s [=navigable/active document=]'s [=Document/origin=].
+    1. If |origin| and |firstPartyOrigin| are not [=same site=], then abort these steps.
 1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null,
     then abort these steps.
 1. Let |site| be the result of running [=obtain a site=] given |origin|.

--- a/index.bs
+++ b/index.bs
@@ -457,6 +457,7 @@ Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorit
     given <var ignore>request</var>.
 
 Note: This spec is written for the case where third-party cookies are blocked. Any cookies written by embedded third-party sites are partitioned.
+    Ignore any cookies set in the Set-Cookie header that are ignored by the user agent before committing to storage.
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -452,14 +452,20 @@ Each [=top-level traversable=] maintains a record of which sites it has saved co
 Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorithm after step 15,
 "... run the "set-cookie-string" parsing algorithm (see [section 5.2](https://httpwg.org/specs/rfc6265.html#set-cookie) of [[COOKIES]]) ...":
 
-1. If cookies were stored in the cookie store in the previous step, then
-    run [=process a fetch storage access for bounce tracking mitigations=]
-    given <var ignore>request</var>.
+1. If cookies were stored in the cookie store in the previous step, then run
+    [=process a fetch storage access for bounce tracking mitigations=] given:
+    <dl>
+        <dt>request</dt>
+        <dd><var ignore>request</var></dd>
+        <dt>partitionedCookies</dt>
+        <dd>whether the <var ignore>Partitioned</var> attribute was set in the Set-Cookie header</dd>
+    </dl>
 
 <div algorithm>
 
 To <dfn>process a fetch storage access for bounce tracking mitigations</dfn>
-given a [=request=] |request|, perform the following steps:
+given a [=request=] |request| and a [=boolean=] |partitionedCookies|,
+perform the following steps:
 
 1. Let |origin| be |request|'s [=request/origin=].
 1. If |origin| is an [=opaque origin=], then abort these steps.
@@ -479,7 +485,7 @@ given a [=request=] |request|, perform the following steps:
         [=browsing context/top-level traversable=].
     1. If |request|'s [=request/destination=] is "`iframe`", then:
         1. Let |firstPartyOrigin| be |topLevelTraversable|'s [=navigable/active document=]'s [=Document/origin=].
-        1. If |origin| and |firstPartyOrigin| are not [=same site=], then abort these steps.
+        1. If |origin| and |firstPartyOrigin| are not [=same site=], and |partitionedCookies| is false, then abort these steps.
 1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]
     is null, abort these steps.
 1. Let |site| be the result of running [=obtain a site=] given |origin|.
@@ -501,7 +507,8 @@ Each [=top-level traversable=] maintains a record of which sites have activated 
 Insert the following steps in the [Handle Fetch](https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm) algorithm after step 23,
 "If the result of running the [Run Service Worker](https://w3c.github.io/ServiceWorker/#run-service-worker) algorithm...":
 
-1. Run [=process a fetch storage access for bounce tracking mitigations=] given <var ignore>request</var>.
+1. Run [=process a fetch storage access for bounce tracking mitigations=] given <var ignore>request</var>
+    and <var ignore>partitionedCookies</var> set to false.
 
 <h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
 

--- a/index.bs
+++ b/index.bs
@@ -487,8 +487,6 @@ given a [=request=] |request|, perform the following steps:
     [=top-level traversable/bounce tracking record=]'s
     [=bounce tracking record/storage access set=].
 
-Issue: TODO: Handle iframes for client-side redirects.
-
 </div>
 
 Note: We currently don't treat cookie reads as stateful, but this would be a

--- a/index.bs
+++ b/index.bs
@@ -291,6 +291,11 @@ for this work, but the text in this section is intended for adoption across all 
 section is not complete yet, and as the algorithms are developed, they will be specified here and
 presented for review.
 
+This spec is written for the case where the following features are enabled:
+    * All third-party cookies are blocked.
+    * All cookies written by embedded third-party sites are partitioned.
+    * All storage written by embedded third-party sites is partitioned.
+
 <p class=note>
 The following is a work-in-progress and does not yet reflect any consensus in
 the PrivacyCG.
@@ -456,9 +461,8 @@ Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorit
     run [=process a fetch storage access for bounce tracking mitigations=]
     given <var ignore>request</var>.
 
-Note: This spec is written for the case where third-party cookies are blocked. Any cookies written by embedded third-party sites are partitioned.
-    Ignore any cookies set in the Set-Cookie header that are ignored by the user agent before committing to storage, such as non-partitioned
-    third-party cookies.
+Note: If the `Set-Cookie` header includes any cookies that the user agent ignores, for example because it's blocking third-party cookies,
+    they're not considered "stored in the cookie store" in this algorithm.
 
 <div algorithm>
 
@@ -515,8 +519,6 @@ Insert the following steps in the <a spec="storage">obtain a storage bottle map<
 Issue(whatwg/storage#165): This patch has to be run whenever a site accesses non-cookie storage.
 <a spec="storage">Obtain a storage bottle map</a> is the intended hook for this, but it does not currently have full coverage across specs that use storage.
 So this patch is not comprehensive.</p>
-
-Note: This spec is written for the case where all storage access by embedded third-party sites is partitioned.
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -457,7 +457,8 @@ Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorit
     given <var ignore>request</var>.
 
 Note: This spec is written for the case where third-party cookies are blocked. Any cookies written by embedded third-party sites are partitioned.
-    Ignore any cookies set in the Set-Cookie header that are ignored by the user agent before committing to storage.
+    Ignore any cookies set in the Set-Cookie header that are ignored by the user agent before committing to storage, such as non-partitioned
+    third-party cookies.
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -452,20 +452,16 @@ Each [=top-level traversable=] maintains a record of which sites it has saved co
 Insert the following steps in the <a spec="fetch">HTTP-network fetch</a> algorithm after step 15,
 "... run the "set-cookie-string" parsing algorithm (see [section 5.2](https://httpwg.org/specs/rfc6265.html#set-cookie) of [[COOKIES]]) ...":
 
-1. If cookies were stored in the cookie store in the previous step, then run
-    [=process a fetch storage access for bounce tracking mitigations=] given:
-    <dl>
-        <dt>request</dt>
-        <dd><var ignore>request</var></dd>
-        <dt>partitionedCookies</dt>
-        <dd>whether the <var ignore>Partitioned</var> attribute was set in the Set-Cookie header</dd>
-    </dl>
+1. If cookies were stored in the cookie store in the previous step, then
+    run [=process a fetch storage access for bounce tracking mitigations=]
+    given <var ignore>request</var>.
+
+Note: This spec is written for the case where third-party cookies are blocked. Any cookies written by embedded third-party sites are partitioned.
 
 <div algorithm>
 
 To <dfn>process a fetch storage access for bounce tracking mitigations</dfn>
-given a [=request=] |request| and a [=boolean=] |partitionedCookies|,
-perform the following steps:
+given a [=request=] |request|, perform the following steps:
 
 1. Let |origin| be |request|'s [=request/origin=].
 1. If |origin| is an [=opaque origin=], then abort these steps.
@@ -483,9 +479,6 @@ perform the following steps:
     1. Let |topLevelTraversable| be |request|'s [=request/reserved client=]'s
         [=environment/target browsing context=]'s
         [=browsing context/top-level traversable=].
-    1. If |request|'s [=request/destination=] is "`iframe`", then:
-        1. Let |firstPartyOrigin| be |topLevelTraversable|'s [=navigable/active document=]'s [=Document/origin=].
-        1. If |origin| and |firstPartyOrigin| are not [=same site=], and |partitionedCookies| is false, then abort these steps.
 1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=]
     is null, abort these steps.
 1. Let |site| be the result of running [=obtain a site=] given |origin|.
@@ -507,8 +500,7 @@ Each [=top-level traversable=] maintains a record of which sites have activated 
 Insert the following steps in the [Handle Fetch](https://w3c.github.io/ServiceWorker/#on-fetch-request-algorithm) algorithm after step 23,
 "If the result of running the [Run Service Worker](https://w3c.github.io/ServiceWorker/#run-service-worker) algorithm...":
 
-1. Run [=process a fetch storage access for bounce tracking mitigations=] given <var ignore>request</var>
-    and <var ignore>partitionedCookies</var> set to false.
+1. Run [=process a fetch storage access for bounce tracking mitigations=] given <var ignore>request</var>.
 
 <h5 id="bounce-tracking-mitigations-storage-access-monkey-patch">Storage Access Monkey Patch</h5>
 
@@ -522,6 +514,8 @@ Issue(whatwg/storage#165): This patch has to be run whenever a site accesses non
 <a spec="storage">Obtain a storage bottle map</a> is the intended hook for this, but it does not currently have full coverage across specs that use storage.
 So this patch is not comprehensive.</p>
 
+Note: This spec is written for the case where all storage access by embedded third-party sites is partitioned.
+
 <div algorithm>
 
 To <dfn>process a general storage access for bounce tracking mitigations</dfn>
@@ -533,14 +527,11 @@ Note: At time of writing, <a spec="storage">obtain a storage bottle map</a> can 
 but this will be refactored to support [=service workers=] which attempt to access storage on every navigation, and thus is not considered
 when updating the [=bounce tracking record/storage access set=].
 
+1. Let |origin| be |environment|'s [=environment/top-level origin=].
+1. If |origin| is null or an [=opaque origin=], then abort these steps.
 1. Let |browsingContext| be |environment|'s [=environment/target browsing context=].
 1. If |browsingContext| is null, then abort these steps.
-1. Let |activeDocument| be |browsingContext|'s active document.
-1. Let |origin| be |activeDocument|'s [=Document/origin=].
 1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
-1. If |activeDocument|'s node navigable's [=navigable/parent=] is non-null:
-    1. Let |firstPartyOrigin| be |topLevelTraversable|'s [=navigable/active document=]'s [=Document/origin=].
-    1. If |origin| and |firstPartyOrigin| are not [=same site=], then abort these steps.
 1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null,
     then abort these steps.
 1. Let |site| be the result of running [=obtain a site=] given |origin|.


### PR DESCRIPTION
The current spec should require no changes for iframe/subresource access - these are already tracked as stateful accesses under the top-level site. If we assume partitioned 3P cookies and 3P storage, all accesses by a 3P subresource may be used as a DIPS workaround (via a client-side redirect) and should be tracked accordingly.

@wanderview


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/49.html" title="Last updated on Jun 16, 2023, 6:36 PM UTC (0bd00f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/49/11a796f...amaliev:0bd00f4.html" title="Last updated on Jun 16, 2023, 6:36 PM UTC (0bd00f4)">Diff</a>