### PR TITLE
Copying privacy/security considerations to spec, adding TAG questionnaire

### DIFF
--- a/bounce-tracking-explainer.md
+++ b/bounce-tracking-explainer.md
@@ -143,7 +143,7 @@ For this reason we are not currently pursuing this approach, but acknowledge it 
 
 # Privacy and Security Considerations
 
-This feature will likely need to store information about sites that have a user interaction, some amount of view time, or [engagement](https://www.chromium.org/developers/design-documents/site-engagement/).  This information is not directly exposed to sites, however, it can be indirectly observed.  For example, if `tracker.example` reports back its oldest existing state to `site1.example`, then `site1.example` could infer that `tracker.example` has had an interaction.  If it does not report any long-lived state, however, then `site1.example` could infer that the state was wiped.
+This feature stores information about sites that have a user interaction, some amount of view time, or [engagement](https://www.chromium.org/developers/design-documents/site-engagement/).  This information is not directly exposed to sites, however, it can be indirectly observed.  For example, if `tracker.example` reports back its oldest existing state to `site1.example`, then `site1.example` could infer that `tracker.example` has had an interaction.  If it does not report any long-lived state, however, then `site1.example` could infer that the state was wiped.
 
 In addition, there are potential scenarios where the existence of an interaction could be accessed through existing XS leaks in the platform.  Consider a scenario where a target site has an existing endpoint that causes an automatic redirect that triggers the bounce tracking mitigations.  An attacker could use existing XS leaks to determine if any logged-in state is present on a target site and then look to see if that state disappears after triggering the bounce.
 

--- a/index.bs
+++ b/index.bs
@@ -721,6 +721,43 @@ following steps:
 
 </div>
 
+<h2 id="privacy-and-security-considerations">Privacy and Security Considerations</h2>
+
+This feature will likely need to store information about sites that have a user interaction, some 
+amount of view time, or [engagement](https://www.chromium.org/developers/design-documents/site-engagement/). 
+This information is not directly exposed to sites, however, it can be indirectly observed.  For example, 
+if `tracker.example` reports back its oldest existing state to `site1.example`, then `site1.example` could 
+infer that `tracker.example` has had an interaction.  If it does not report any long-lived state, however, 
+then `site1.example` could infer that the state was wiped.
+
+In addition, there are potential scenarios where the existence of an interaction could be accessed through 
+existing XS leaks in the platform.  Consider a scenario where a target site has an existing endpoint that 
+causes an automatic redirect that triggers the bounce tracking mitigations.  An attacker could use existing 
+XS leaks to determine if any logged-in state is present on a target site and then look to see if that state 
+disappears after triggering the bounce.
+
+The information leak from tracker to site does not seem very significant.  At a minimum, the proposed 
+mitigations do not make the situation worse and without the mitigations there is a greater potential for a 
+tracker to communicate state to the target site.
+
+The cross-site adversarial information leak is more concerning.  Solutions designed for this effort should 
+take this threat into account and attempt to mitigate it.  For example, delaying or fuzzing the timing of 
+storage wiping could lessen the impact of the leak.  Ultimately, though, it may be necessary to weigh the 
+cost of this 1 bit information leak against the gains in mitigating bounce tracking.
+
+Another threat that should be considered by any solution is the possibility that an attacker will trick a 
+user into visiting an existing redirect endpoint on a site that they care about and somehow trigger their 
+storage to be deleted.  The current plan, however, is to already look at signals that a user cares about a 
+site for legitimate use cases, in order to avoid wiping data they care about.  This threat just puts more 
+weight on getting these signals correct.
+
+Otherwise this effort does not store or expose any new types of information.  It does not create any new 
+cross-origin communication or storage capabilities.
+
+There is some implementation complexity to be aware of when wiping storage.  The browser must be careful 
+not to wipe storage out from under a site actively using it.  This could lead to poor interop and broken 
+web sites.
+
 <h2 id="acknowledgements" class="no-num">Acknowledgements</h2>
 
 Many thanks to the Privacy Community Group for many good discussions about this proposal.

--- a/index.bs
+++ b/index.bs
@@ -614,6 +614,10 @@ Every [=bounce tracking timer period=] the user agent should run the
 [=bounce tracking timer=] algorithm given the [=wall clock=]'s
 [=wall clock/unsafe current time=].
 
+Note: Running the deletion algorithm on a global timer has the effect of adding fuzz to the
+    delay between stateful bounce and data deletion. This mitigates adversarial leaks of
+    interaction and bounce times. (See "Privacy and Security Considerations", below.)
+
 <div algorithm>
 
 To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
@@ -723,12 +727,12 @@ following steps:
 
 <h2 id="privacy-and-security-considerations">Privacy and Security Considerations</h2>
 
-This feature will likely need to store information about sites that have a user interaction, some 
-amount of view time, or [engagement](https://www.chromium.org/developers/design-documents/site-engagement/). 
-This information is not directly exposed to sites, however, it can be indirectly observed.  For example, 
-if `tracker.example` reports back its oldest existing state to `site1.example`, then `site1.example` could 
-infer that `tracker.example` has had an interaction.  If it does not report any long-lived state, however, 
-then `site1.example` could infer that the state was wiped.
+This feature stores information about sites that have a user interaction, some amount of view time, or
+[engagement](https://www.chromium.org/developers/design-documents/site-engagement/). This information is 
+not directly exposed to sites, however, it can be indirectly observed.  For example, if `tracker.example` 
+reports back its oldest existing state to `site1.example`, then `site1.example` could infer that 
+`tracker.example` has had an interaction.  If it does not report any long-lived state, however, then 
+`site1.example` could infer that the state was wiped.
 
 In addition, there are potential scenarios where the existence of an interaction could be accessed through 
 existing XS leaks in the platform.  Consider a scenario where a target site has an existing endpoint that 

--- a/tag-privacy-security.md
+++ b/tag-privacy-security.md
@@ -1,0 +1,39 @@
+# TAG Security & Privacy Questionnaire Answers #
+
+* **Author:** amaliev@google.com
+* **Questionnaire Source:** https://www.w3.org/TR/security-privacy-questionnaire/#questions
+
+## Questions ##
+
+* **What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?**
+  * We are not directly exposing new information.  We are deleting site state based on user behavior, however, and this does run the risk of leaking information about that user behavior.  We are mitigating this by fuzzing deletion time to make it harder to detect deletion and infer leaked information.
+* **Is this specification exposing the minimum amount of information necessary to power the feature?**
+  * Yes. Both user activation timestamps and stateful bounce timestamps are absolutely necessary for the feature.
+* **How does this specification deal with personal information or personally-identifiable information or information derived thereof?**
+  * This proposal does not deal with PII.
+* **How does this specification deal with sensitive information?**
+  * It doesn’t.
+* **Does this specification introduce new state for an origin that persists across browsing sessions?**
+  * Yes. For every eTLD+1 site, it stores the timestamp of the last user activation and the last stateful bounce on that origin. However, this data is cleared by a global timer, after an implementation-defined duration.
+* **What information from the underlying platform, e.g. configuration data, is exposed by this specification to an origin?**
+  * None.
+* **Does this specification allow an origin access to sensors on a user’s device**
+  * No.
+* **What data does this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.**
+  * None.
+* **Does this specification enable new script execution/loading mechanisms?**
+  * No.
+* **Does this specification allow an origin to access other devices?**
+  * No.
+* **Does this specification allow an origin some measure of control over a user agent’s native UI?**
+  * No.
+* **What temporary identifiers might this this specification create or expose to the web?**
+  * It tracks the last user activation and stateful bounce for each eTLD+1 site, as well as a set of bounced sites and sites that access storage for every navigation. However, these are eventually cleared. They are not directly exposed to the web, but they may be leaked to attackers who may be able to observe deleted site state in certain scenarios.  We mitigate this leakage by using an algorithm that makes it hard for an attacker to know when deletions will occur.
+* **How does this specification distinguish between behavior in first-party and third-party contexts?**
+  * We are interested primarily in first-party state, as bounce tracking can use it to simulate a 3P cookie on a different site. We also roll-up any 3P state accessed and attribute it to the top-level document.
+* **How does this specification work in the context of a user agent’s Private \ Browsing or "incognito" mode?**
+  * A user’s Private Browsing mode may have more restrictive settings to block third-party cookies. This proposal does not change that behavior or create new differences.
+* **Does this specification have a "Security Considerations" and "Privacy Considerations" section?**
+  * Yes.
+* **Does this specification allow downgrading default security characteristics?**
+  * No.


### PR DESCRIPTION
Copying existing privacy/security section from explainer to spec for easier access.

Adding privacy/security questionnaire for upcoming TAG review.

@wanderview


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/51.html" title="Last updated on Jun 16, 2023, 7:44 PM UTC (3e24b59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/51/f234faf...amaliev:3e24b59.html" title="Last updated on Jun 16, 2023, 7:44 PM UTC (3e24b59)">Diff</a>