### PR TITLE
Add a note describing the behavior for popup trackers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -423,7 +423,7 @@ Add the following argument to the [Discover From External Source](https://w3c.gi
 Insert the following steps in the [Discover From External Source](https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot) algorithm
     in step 17, under "If any authenticator indicates success":
 
-1. Run [=process a Web Authentication assertion for bounce tracking mitigations=] given <var ignore>callerOrigin</var> and <var ignore>browsingContext</var>.
+1. Run [=process a Web Authentication assertion for bounce tracking mitigations=] given <var ignore>browsingContext</var>.
 
 <div algorithm>
 

--- a/index.bs
+++ b/index.bs
@@ -423,7 +423,7 @@ Add the following argument to the [Discover From External Source](https://w3c.gi
 Insert the following steps in the [Discover From External Source](https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot) algorithm
     in step 17, under "If any authenticator indicates success":
 
-1. Run [=process a Web Authentication assertion for bounce tracking mitigations=] given <var ignore>browsingContext</var>.
+1. Run [=process a Web Authentication assertion for bounce tracking mitigations=] given <var ignore>callerOrigin</var> and <var ignore>browsingContext</var>.
 
 <div algorithm>
 
@@ -466,6 +466,7 @@ To <dfn>process navigation start for bounce tracking</dfn> given a [=navigable=]
 1. Remove any queued global tasks to [=record stateful bounces for bounce tracking=] from the [=networking task source=].
 1. Let |origin| be |sourceDocument|'s [=Document/origin=].
 1. If |origin| is an [=opaque origin=], set |initialHost| to [=empty host=].
+
 1. Otherwise,
     1. Let |site| be the result of running [=obtain a site=] given |origin|.
     1. Set |initialHost| to |site|'s [=host=].
@@ -473,6 +474,12 @@ To <dfn>process navigation start for bounce tracking</dfn> given a [=navigable=]
     1. Set |navigable|'s [=top-level traversable/bounce tracking record=] to a new
         [=bounce tracking record=] with [=bounce tracking record/initial host=]
         set to |initialHost|.
+
+Note: This includes the case where the current navigation was initiated by another navigable, e.g. when opening
+    a link in a new tab. In this case, |sourceDocument| is set to the opener Document, and the new bounce tracking
+    record has its [=bounce tracking record/initial host=] set to the opener host. This ensures that trackers opened
+    in new tabs are detected as distinct from the [=bounce tracking record/initial host=] in the new  [=bounce tracking record=].
+
 1. Otherwise,
     1. If |sourceSnapshotParams|'s <a spec="html">has transient activation</a> is true:
         1. Run [=record stateful bounces for bounce tracking=] given |navigable|'s [=navigable/active document=]'s [=relevant global object=].

--- a/index.bs
+++ b/index.bs
@@ -466,7 +466,6 @@ To <dfn>process navigation start for bounce tracking</dfn> given a [=navigable=]
 1. Remove any queued global tasks to [=record stateful bounces for bounce tracking=] from the [=networking task source=].
 1. Let |origin| be |sourceDocument|'s [=Document/origin=].
 1. If |origin| is an [=opaque origin=], set |initialHost| to [=empty host=].
-
 1. Otherwise,
     1. Let |site| be the result of running [=obtain a site=] given |origin|.
     1. Set |initialHost| to |site|'s [=host=].


### PR DESCRIPTION
Given how cross-navigable navigations are handled in the spec, the existing algo already supports setting the correct initial host for popup redirects.

Resolves #50 

@wanderview


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/54.html" title="Last updated on Jun 23, 2023, 5:10 PM UTC (00064ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/54/6e34e31...amaliev:00064ed.html" title="Last updated on Jun 23, 2023, 5:10 PM UTC (00064ed)">Diff</a>