### PR TITLE
Add note for browser-integrated accounts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -442,6 +442,10 @@ To <dfn>process a Web Authentication assertion for bounce tracking mitigations</
 
 </div>
 
+Note: It's also reasonable to treat signin to a browser-integrated account as a user activation for
+    bounce-tracking purposes. Such an interaction could be stored in the [=user activation map=]
+    for the host of the identity provider and/or the host domain of the account.
+
 <h4 id="bounce-tracking-mitigation-stateful-bounce-detection">Stateful Bounce
 Detection</h4>
 


### PR DESCRIPTION
As discussed offline, we mention that browser-integrated account signin can also be considered a user activation, even though this flow isn't explicitly defined in a spec.

@wanderview


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/55.html" title="Last updated on Jun 23, 2023, 6:36 PM UTC (f0b917d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/55/2e068aa...amaliev:f0b917d.html" title="Last updated on Jun 23, 2023, 6:36 PM UTC (f0b917d)">Diff</a>