### PR TITLE
Fix general storage access navigable, add worker logic

### DIFF
--- a/bounce-tracking-explainer.md
+++ b/bounce-tracking-explainer.md
@@ -69,7 +69,7 @@ This tracking scenario will be mitigated by this effort by wiping the tracker do
 
 Another tracking scenario involves a source site redirecting all outgoing links through a tracker domain.  Again, the tracker domain is able to access first-party storage in this scenario and has no first-party relationship with the user.
 
-![Diagram 2](diagrams/explainer_diagram_2.png)
+![Diagram 2](~/diagrams/explainer_diagram_2.png)
 
 This tracking scenario will be mitigated by this effort by wiping the tracker domain's storage.
 

--- a/bounce-tracking-explainer.md
+++ b/bounce-tracking-explainer.md
@@ -69,7 +69,7 @@ This tracking scenario will be mitigated by this effort by wiping the tracker do
 
 Another tracking scenario involves a source site redirecting all outgoing links through a tracker domain.  Again, the tracker domain is able to access first-party storage in this scenario and has no first-party relationship with the user.
 
-![Diagram 2](~/diagrams/explainer_diagram_2.png)
+![Diagram 2](diagrams/explainer_diagram_2.png)
 
 This tracking scenario will be mitigated by this effort by wiping the tracker domain's storage.
 

--- a/index.bs
+++ b/index.bs
@@ -575,11 +575,11 @@ but this will be refactored to support [=service workers=] which attempt to acce
 when updating the [=bounce tracking record/storage access set=].
 
 2. Let |origin| be |environment|'s [=environment/top-level origin=].
-1. If |origin| is null or an [=opaque origin=], then abort these steps.
-1. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
-1. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
-1. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
-1. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
+3. If |origin| is null or an [=opaque origin=], then abort these steps.
+4. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
+5. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
+6. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
+7. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
     1. Let |ownerQueue| be an [=queue/empty=] [=queue=] of [=document=] or {{WorkerGlobalScope}} objects.
     1. [=queue/Enqueue=] |global| onto |ownerQueue|.
     1. [=iteration/While=] |ownerQueue| is not [=queue/empty=],
@@ -587,7 +587,12 @@ when updating the [=bounce tracking record/storage access set=].
         1. If |owner| is a [=document=] object, [=set/append=] |owner|'s [=node navigable=] onto |navigables|.
         1. If |owner| is a {{WorkerGlobalScope}} object, then [=set/For each=] |owner| in |global|'s [=WorkerGlobalScope/owner set=],
             [=queue/enqueue=] |owner| onto |ownerQueue|.
-1. [=set/For each=] |navigable| in |navigables|:
+
+Note: Handling {{WorkerGlobalScope}} covers all storage access from a dedicated worker ({{DedicatedWorkerGlobalScope}}) or a shared worker
+({{SharedWorkerGlobalScope}}). This doesn't apply to shared workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
+during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object for general storage access.
+
+8. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.
     1. If |navigable|'s [=top-level traversable/bounce tracking record=] is null, then abort these steps.
     1. Let |site| be the result of running [=obtain a site=] given |origin|.

--- a/index.bs
+++ b/index.bs
@@ -574,17 +574,23 @@ Note: At time of writing, <a spec="storage">obtain a storage bottle map</a> can 
 but this will be refactored to support [=service workers=] which attempt to access storage on every navigation, and thus is not considered
 when updating the [=bounce tracking record/storage access set=].
 
-1. Let |origin| be |environment|'s [=environment/top-level origin=].
+2. Let |origin| be |environment|'s [=environment/top-level origin=].
 1. If |origin| is null or an [=opaque origin=], then abort these steps.
-1. Let |browsingContext| be |environment|'s [=environment/target browsing context=].
-1. If |browsingContext| is null, then abort these steps.
-1. Let |topLevelTraversable| be |browsingContext|'s [=browsing context/top-level traversable=].
-1. If |topLevelTraversable|'s [=top-level traversable/bounce tracking record=] is null,
-    then abort these steps.
-1. Let |site| be the result of running [=obtain a site=] given |origin|.
-1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
-        [=top-level traversable/bounce tracking record=]'s
-        [=bounce tracking record/storage access set=].
+1. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
+1. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
+1. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
+1. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
+    1. Let |ownerSet| be |global|'s [=WorkerGlobalScope/owner set=].
+    1. [=set/For each=] |owner| in |ownerSet|:
+        1. If |owner| is a [=document=] object, [=set/append=] |owner|'s [=node navigable=] onto |navigables|.
+        1. If |owner| is a {{WorkerGlobalScope}} object, [=set/append=] |owner| onto |ownerSet|.
+1. [=set/For each=] |navigable| in |navigables|:
+    1. If |navigable| is not a [=top-level traversable=], then abort these steps.
+    1. If |navigable|'s [=top-level traversable/bounce tracking record=] is null, then abort these steps.
+    1. Let |site| be the result of running [=obtain a site=] given |origin|.
+    1. [=set/Append=] |site|'s [=host=] to |navigable|'s
+            [=top-level traversable/bounce tracking record=]'s
+            [=bounce tracking record/storage access set=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -589,8 +589,9 @@ when updating the [=bounce tracking record/storage access set=].
             [=queue/enqueue=] |owner| onto |ownerQueue|.
 
 Note: Handling {{WorkerGlobalScope}} covers all storage access from a dedicated worker ({{DedicatedWorkerGlobalScope}}) or a shared worker
-({{SharedWorkerGlobalScope}}). This doesn't apply to shared workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
-during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object for general storage access.
+({{SharedWorkerGlobalScope}}). This doesn't apply to service workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
+during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object when a service worker is
+accessed using navigator.serviceWorker.getRegistration().
 
 8. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -580,10 +580,13 @@ when updating the [=bounce tracking record/storage access set=].
 1. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
 1. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
 1. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
-    1. Let |ownerSet| be |global|'s [=WorkerGlobalScope/owner set=].
-    1. [=set/For each=] |owner| in |ownerSet|:
+    1. Let |ownerQueue| be an [=queue/empty=] [=queue=] of [=document=] or {{WorkerGlobalScope}} objects.
+    1. [=queue/Enqueue=] |global| onto |ownerQueue|.
+    1. [=iteration/While=] |ownerQueue| is not [=queue/empty=],
+        1. [=queue/Dequeue=] |owner| from |ownerQueue|.
         1. If |owner| is a [=document=] object, [=set/append=] |owner|'s [=node navigable=] onto |navigables|.
-        1. If |owner| is a {{WorkerGlobalScope}} object, [=set/append=] |owner| onto |ownerSet|.
+        1. If |owner| is a {{WorkerGlobalScope}} object, then [=set/For each=] |owner| in |global|'s [=WorkerGlobalScope/owner set=],
+            [=queue/enqueue=] |owner| onto |ownerQueue|.
 1. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.
     1. If |navigable|'s [=top-level traversable/bounce tracking record=] is null, then abort these steps.


### PR DESCRIPTION
Fix incorrect reference of navigable from context of general storage access.

This handles both the Window case (storage access from main thread) and the WorkerGlobalScope case (which could be on a dedicated worker thread or a shared worker used by multiple documents). In the latter case we attribute the storage access to all of the open documents using the shared worker.

Closes #57

@wanderview


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/58.html" title="Last updated on Jul 13, 2023, 2:44 PM UTC (681f7e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/58/03d9fa4...amaliev:681f7e8.html" title="Last updated on Jul 13, 2023, 2:44 PM UTC (681f7e8)">Diff</a>