### PR TITLE
Add user activation set to bounce tracking record

### DIFF
--- a/bounce-tracking-explainer.md
+++ b/bounce-tracking-explainer.md
@@ -71,7 +71,7 @@ This tracking scenario will be mitigated by this effort by wiping the tracker do
 
 Another tracking scenario involves a source site redirecting all outgoing links through a tracker domain.  Again, the tracker domain is able to access first-party storage in this scenario and has no first-party relationship with the user.
 
-![Diagram 2](diagrams/explainer_diagram_2.png)
+![Diagram 2](~/diagrams/explainer_diagram_2.png)
 
 This tracking scenario will be mitigated by this effort by wiping the tracker domain's storage.
 

--- a/bounce-tracking-explainer.md
+++ b/bounce-tracking-explainer.md
@@ -71,7 +71,7 @@ This tracking scenario will be mitigated by this effort by wiping the tracker do
 
 Another tracking scenario involves a source site redirecting all outgoing links through a tracker domain.  Again, the tracker domain is able to access first-party storage in this scenario and has no first-party relationship with the user.
 
-![Diagram 2](~/diagrams/explainer_diagram_2.png)
+![Diagram 2](diagrams/explainer_diagram_2.png)
 
 This tracking scenario will be mitigated by this effort by wiping the tracker domain's storage.
 

--- a/index.bs
+++ b/index.bs
@@ -580,25 +580,16 @@ but this will be refactored to support [=service workers=] which attempt to acce
 when updating the [=bounce tracking record/storage access set=].
 
 2. Let |origin| be |environment|'s [=environment/top-level origin=].
-3. If |origin| is null or an [=opaque origin=], then abort these steps.
-4. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
-5. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
-6. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
-7. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
-    1. Let |ownerQueue| be an [=queue/empty=] [=queue=] of [=document=] or {{WorkerGlobalScope}} objects.
-    1. [=queue/Enqueue=] |global| onto |ownerQueue|.
-    1. [=iteration/While=] |ownerQueue| is not [=queue/empty=],
-        1. [=queue/Dequeue=] |owner| from |ownerQueue|.
+1. If |origin| is null or an [=opaque origin=], then abort these steps.
+1. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
+1. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
+1. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
+1. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
+    1. Let |ownerSet| be |global|'s [=WorkerGlobalScope/owner set=].
+    1. [=set/For each=] |owner| in |ownerSet|:
         1. If |owner| is a [=document=] object, [=set/append=] |owner|'s [=node navigable=] onto |navigables|.
-        1. If |owner| is a {{WorkerGlobalScope}} object, then [=set/For each=] |owner| in |global|'s [=WorkerGlobalScope/owner set=],
-            [=queue/enqueue=] |owner| onto |ownerQueue|.
-
-Note: Handling {{WorkerGlobalScope}} covers all storage access from a dedicated worker ({{DedicatedWorkerGlobalScope}}) or a shared worker
-({{SharedWorkerGlobalScope}}). This doesn't apply to service workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
-during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object when a service worker is
-accessed using navigator.serviceWorker.getRegistration().
-
-8. [=set/For each=] |navigable| in |navigables|:
+        1. If |owner| is a {{WorkerGlobalScope}} object, [=set/append=] |owner| onto |ownerSet|.
+1. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.
     1. If |navigable|'s [=top-level traversable/bounce tracking record=] is null, then abort these steps.
     1. Let |site| be the result of running [=obtain a site=] given |origin|.

--- a/index.bs
+++ b/index.bs
@@ -580,11 +580,11 @@ but this will be refactored to support [=service workers=] which attempt to acce
 when updating the [=bounce tracking record/storage access set=].
 
 2. Let |origin| be |environment|'s [=environment/top-level origin=].
-1. If |origin| is null or an [=opaque origin=], then abort these steps.
-1. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
-1. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
-1. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
-1. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
+3. If |origin| is null or an [=opaque origin=], then abort these steps.
+4. Let |global| be |environment|'s [=environment settings object/realm execution context=]'s [=global object=].
+5. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
+6. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
+7. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
     1. Let |ownerQueue| be an [=queue/empty=] [=queue=] of [=document=] or {{WorkerGlobalScope}} objects.
     1. [=queue/Enqueue=] |global| onto |ownerQueue|.
     1. [=iteration/While=] |ownerQueue| is not [=queue/empty=],
@@ -592,7 +592,12 @@ when updating the [=bounce tracking record/storage access set=].
         1. If |owner| is a [=document=] object, [=set/append=] |owner|'s [=node navigable=] onto |navigables|.
         1. If |owner| is a {{WorkerGlobalScope}} object, then [=set/For each=] |owner| in |global|'s [=WorkerGlobalScope/owner set=],
             [=queue/enqueue=] |owner| onto |ownerQueue|.
-1. [=set/For each=] |navigable| in |navigables|:
+
+Note: Handling {{WorkerGlobalScope}} covers all storage access from a dedicated worker ({{DedicatedWorkerGlobalScope}}) or a shared worker
+({{SharedWorkerGlobalScope}}). This doesn't apply to shared workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
+during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object for general storage access.
+
+8. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.
     1. If |navigable|'s [=top-level traversable/bounce tracking record=] is null, then abort these steps.
     1. Let |site| be the result of running [=obtain a site=] given |origin|.

--- a/index.bs
+++ b/index.bs
@@ -50,7 +50,7 @@ spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265/
     type: dfn
         text: cookie store; url: section-5.3
         text: domain-match; url: section-5.1.3
-spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234/
+spec: RFC9111; urlPrefix: https://tools.ietf.org/html/rfc9111/
     type: dfn
         text: network cache; url: section-2
 </pre>
@@ -353,6 +353,8 @@ A <dfn>bounce tracking record</dfn> is a [=struct=] whose items are:
 <dd>A [=set=] of [=sites=]' [=hosts=]. All server-side and client-side redirects hit during this [=extended navigation=].</dd>
 <dt><dfn>storage access set</dfn></dt>
 <dd>A [=set=] of [=sites=]' [=hosts=]. All sites which accessed storage during this [=extended navigation=].</dd>
+<dt><dfn>user activation set</dfn></dt>
+<dd>A [=set=] of [=sites=]' [=hosts=]. All sites which received a user activation during this [=extended navigation=].</dd>
 </dl>
 
 <h4 id="bounce-tracking-mitigations-data-model-constants">Constants</h4>
@@ -405,6 +407,9 @@ the following steps:
 1. Set [=user activation map=][|host|] to |topDocument|'s
     [=relevant settings object=]'s
     [=environment settings object/current wall time=].
+1. If |navigable|'s [=top-level traversable/bounce tracking record=] is not null:
+    1. [=set/Append=] |host| to |navigable|'s [=top-level traversable/bounce tracking record=]'s
+        [=bounce tracking record/storage access set=].
 
 </div>
 
@@ -493,6 +498,8 @@ Note: This includes the case where the current navigation was initiated by anoth
         1. Run [=record stateful bounces for bounce tracking=] given |navigable|'s [=navigable/active document=]'s [=relevant global object=].
         1. Set |navigable|'s [=top-level traversable/bounce tracking record=] to a new [=bounce tracking record=] with
             [=bounce tracking record/initial host=] set to |initialHost|.
+        1. [=set/Append=] |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s
+            [=bounce tracking record/user activation set=].
     1. Otherwise, add |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s [=bounce tracking record/bounce set=].
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -594,8 +594,9 @@ when updating the [=bounce tracking record/storage access set=].
             [=queue/enqueue=] |owner| onto |ownerQueue|.
 
 Note: Handling {{WorkerGlobalScope}} covers all storage access from a dedicated worker ({{DedicatedWorkerGlobalScope}}) or a shared worker
-({{SharedWorkerGlobalScope}}). This doesn't apply to shared workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
-during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object for general storage access.
+({{SharedWorkerGlobalScope}}). This doesn't apply to service workers, which rely on [=process a fetch storage access for bounce tracking mitigations=]
+during Fetch events and [=process a general storage access for bounce tracking mitigations=] with a [=Window=] object when a service worker is
+accessed using navigator.serviceWorker.getRegistration().
 
 8. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -585,10 +585,13 @@ when updating the [=bounce tracking record/storage access set=].
 1. Let |navigables| be an [=set/empty=] [=set=] of [=navigables=].
 1. If |global| is a [=Window=] object, [=set/append=] |global|'s [=associated document=]'s [=node navigable=] onto |navigables|.
 1. Otherwise, if |global| is a {{WorkerGlobalScope}} object,
-    1. Let |ownerSet| be |global|'s [=WorkerGlobalScope/owner set=].
-    1. [=set/For each=] |owner| in |ownerSet|:
+    1. Let |ownerQueue| be an [=queue/empty=] [=queue=] of [=document=] or {{WorkerGlobalScope}} objects.
+    1. [=queue/Enqueue=] |global| onto |ownerQueue|.
+    1. [=iteration/While=] |ownerQueue| is not [=queue/empty=],
+        1. [=queue/Dequeue=] |owner| from |ownerQueue|.
         1. If |owner| is a [=document=] object, [=set/append=] |owner|'s [=node navigable=] onto |navigables|.
-        1. If |owner| is a {{WorkerGlobalScope}} object, [=set/append=] |owner| onto |ownerSet|.
+        1. If |owner| is a {{WorkerGlobalScope}} object, then [=set/For each=] |owner| in |global|'s [=WorkerGlobalScope/owner set=],
+            [=queue/enqueue=] |owner| onto |ownerQueue|.
 1. [=set/For each=] |navigable| in |navigables|:
     1. If |navigable| is not a [=top-level traversable=], then abort these steps.
     1. If |navigable|'s [=top-level traversable/bounce tracking record=] is null, then abort these steps.


### PR DESCRIPTION
Adding a set of all sites that received an interaction during this extended navigation.

This isn't necessary within this spec but will be referenced by heuristics (https://github.com/whatwg/compat/pull/253) to determine which sites are eligible for the redirect heuristic. Note that the appending flow is intentionally different for the initial host and bounced hosts - in the former case we need to wait for the bounce tracking record to be created when the next navigation starts.

Closes #67


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/70.html" title="Last updated on Oct 18, 2024, 7:09 PM UTC (0a139f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/70/5c83f14...amaliev:0a139f9.html" title="Last updated on Oct 18, 2024, 7:09 PM UTC (0a139f9)">Diff</a>