### PR TITLE
Update spec for cookie partition keys and partitioned storage keys

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -766,8 +766,8 @@ following steps:
     1. If |cookie| is not [=partitioned cookie|partitioned=]:
         1. If |cookie|'s [=domain attribute=] is a [=domain-match=] with |host|, add |cookie| to |cookieList|; otherwise, continue.
     1. If |cookie| is [=partitioned cookie|partitioned=]:
-        1. If |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("http", |host|), add |cookie| to |cookieList|.
-        1. If |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("https", |host|), add |cookie| to |cookieList|.
+        1. If the top-level [=site=] in |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("http", |host|), add |cookie| to |cookieList|.
+        1. If the top-level [=site=] in |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("https", |host|), add |cookie| to |cookieList|.
         1. Otherwise, continue.
 1. [=list/For each=] |cookie| in |cookieList|:
     1. Remove |cookie| from the [=cookie store=].

--- a/index.bs
+++ b/index.bs
@@ -709,7 +709,7 @@ To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
         [=obtain a site|site=]'s [=host=] equals |host|,
         then [=iteration/continue=].
     1. [=map/Remove=] |host| from [=stateful bounce tracking map=].
-    1. [=Clear cookies for host=] given |host|.
+    1. [=Clear cookies for site host=] given |host|.
     1. [=Clear non-cookie storage for host=] given |host|.
     1. [=Clear cache for host=] given |host|.
 
@@ -757,7 +757,7 @@ spec.  It would be nice to unify these in the future.</p>
 
 <div algorithm>
 
-To <dfn>clear cookies for host</dfn> given a [=host=] |host|, perform the
+To <dfn>clear cookies for site host</dfn> given a [=site=] [=host=] |host|, perform the
 following steps:
 
 1. Let |cookieList| be a set of cookies, initially empty.

--- a/index.bs
+++ b/index.bs
@@ -784,12 +784,17 @@ the following steps:
 1. For each <a spec=storage>storage shed</a> |shed| held by the user agent or a
     [=traversable navigable=]:
     1. [=map/For each=] |storageKey| -> |storageShelf| of |shed|:
-        1. If |storageKey|'s <a spec=storage for="storage key">origin</a> is an
-            [=opaque origin=], then [=iteration/continue=].
-        1. If |storageKey|'s <a spec=storage for="storage key">origin</a>'s
-            [=origin/host=] does not equal |host|, then [=iteration/continue=].
+        1. Let |topLevelSite| be |storageKey|'s <a spec=storage for="storage key">top-level site</a>.
+        1. If |topLevelSite| is an [=opaque origin=], then [=iteration/continue=].
+        1. If |topLevelSite|'s [=host=] does not equal |host|, then [=iteration/continue=].
         1. Delete all data stored in |storageShelf|.
         1. [=map/Remove=] |storageKey| from |shed|.
+
+Note: This algorithm is written assuming the implementation of the
+    [work-in-progress update](https://github.com/whatwg/storage/pull/144) to
+    the [Storage Standard](https://storage.spec.whatwg.org/) to
+    <a spec=storage lt="storage key">key</a> storage on both an
+    <a spec=storage for="storage key">origin</a> and a top-level site.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -755,8 +755,10 @@ spec.  It would be nice to unify these in the future.</p>
 To <dfn>clear cookies for host</dfn> given a [=host=] |host|, perform the
 following steps:
 
-1. Let |cookieList| be the set of cookies from the [=cookie store=] whose
-    domain attribute is a [=domain-match=] with |host|.
+1. Let |cookieList| be a set of cookies, initially empty.
+1. [=list/For each=] cookie |cookie| in the [=cookie store=], if either of the following is true, add |cookie| to |cookieList|:
+     - |cookie| is not partitioned, and |cookie|'s domain attribute is a [=domain-match=] with |host|; or
+     - |cookie| is partitioned, and |cookie|'s partition key is equal to |host|'s [=obtain a site|site=].
 1. [=list/For each=] |cookie| in |cookieList|:
     1. Remove |cookie| from the [=cookie store=].
 

--- a/index.bs
+++ b/index.bs
@@ -50,9 +50,14 @@ spec: RFC6265; urlPrefix: https://tools.ietf.org/html/rfc6265/
     type: dfn
         text: cookie store; url: section-5.3
         text: domain-match; url: section-5.1.3
+        text: domain attribute; url: section-5.2.3
 spec: RFC7234; urlPrefix: https://tools.ietf.org/html/rfc7234/
     type: dfn
         text: network cache; url: section-2
+spec: PARTITIONED-COOKIES; urlPrefix: https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#
+    type: dfn
+        text: partitioned cookie; url: section-2.1
+        text: partition key; url: section-2.2
 </pre>
 
 <section class="non-normative">
@@ -757,8 +762,8 @@ following steps:
 
 1. Let |cookieList| be a set of cookies, initially empty.
 1. [=list/For each=] cookie |cookie| in the [=cookie store=], if either of the following is true, add |cookie| to |cookieList|:
-     - |cookie| is not partitioned, and |cookie|'s domain attribute is a [=domain-match=] with |host|; or
-     - |cookie| is partitioned, and |cookie|'s partition key is equal to |host|'s [=obtain a site|site=].
+     - |cookie| is not [=partitioned cookie|partitioned=], and |cookie|'s [=domain attribute=] is a [=domain-match=] with |host|; or
+     - |cookie| is [=partitioned cookie|partitioned=], and |cookie|'s [=partition key=] is equal to |host|'s [=obtain a site|site=].
 1. [=list/For each=] |cookie| in |cookieList|:
     1. Remove |cookie| from the [=cookie store=].
 

--- a/index.bs
+++ b/index.bs
@@ -709,7 +709,7 @@ To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
         [=obtain a site|site=]'s [=host=] equals |host|,
         then [=iteration/continue=].
     1. [=map/Remove=] |host| from [=stateful bounce tracking map=].
-    1. [=Clear cookies for site host=] given |host|.
+    1. [=Clear cookies for host=] given |host|.
     1. [=Clear non-cookie storage for host=] given |host|.
     1. [=Clear cache for host=] given |host|.
 
@@ -757,7 +757,7 @@ spec.  It would be nice to unify these in the future.</p>
 
 <div algorithm>
 
-To <dfn>clear cookies for site host</dfn> given a [=site=] [=host=] |host|, perform the
+To <dfn>clear cookies for host</dfn> given a [=host=] |host|, perform the
 following steps:
 
 1. Let |cookieList| be a set of cookies, initially empty.

--- a/index.bs
+++ b/index.bs
@@ -761,9 +761,13 @@ To <dfn>clear cookies for host</dfn> given a [=host=] |host|, perform the
 following steps:
 
 1. Let |cookieList| be a set of cookies, initially empty.
-1. [=list/For each=] cookie |cookie| in the [=cookie store=], if either of the following is true, add |cookie| to |cookieList|:
-     - |cookie| is not [=partitioned cookie|partitioned=], and |cookie|'s [=domain attribute=] is a [=domain-match=] with |host|; or
-     - |cookie| is [=partitioned cookie|partitioned=], and |cookie|'s [=partition key=] is equal to |host|'s [=obtain a site|site=].
+1. [=list/For each=] cookie |cookie| in the [=cookie store=]:
+    1. If |cookie| is not [=partitioned cookie|partitioned=]:
+        1. If |cookie|'s [=domain attribute=] is a [=domain-match=] with |host|, add |cookie| to |cookieList|; otherwise, continue.
+    1. If |cookie| is [=partitioned cookie|partitioned=]:
+        1. If |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("http", |host|), add |cookie| to |cookieList|.
+        1. If |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("https", |host|), add |cookie| to |cookieList|.
+        1. Otherwise, continue.
 1. [=list/For each=] |cookie| in |cookieList|:
     1. Remove |cookie| from the [=cookie store=].
 

--- a/index.bs
+++ b/index.bs
@@ -784,7 +784,7 @@ the following steps:
 1. For each <a spec=storage>storage shed</a> |shed| held by the user agent or a
     [=traversable navigable=]:
     1. [=map/For each=] |storageKey| -> |storageShelf| of |shed|:
-        1. Let |topLevelSite| be |storageKey|'s <a spec=storage for="storage key">top-level site</a>.
+        1. Let |topLevelSite| be |storageKey|'s top-level site.
         1. If |topLevelSite| is an [=opaque origin=], then [=iteration/continue=].
         1. If |topLevelSite|'s [=host=] does not equal |host|, then [=iteration/continue=].
         1. Delete all data stored in |storageShelf|.

--- a/index.bs
+++ b/index.bs
@@ -760,6 +760,7 @@ spec.  It would be nice to unify these in the future.</p>
 To <dfn>clear cookies for host</dfn> given a [=host=] |host|, perform the
 following steps:
 
+1. [=Assert=]: |host|'s [=host/registrable domain=] is |host| or null.
 1. Let |cookieList| be a set of cookies, initially empty.
 1. [=list/For each=] cookie |cookie| in the [=cookie store=]:
     1. If |cookie| is not [=partitioned cookie|partitioned=]:

--- a/index.bs
+++ b/index.bs
@@ -764,11 +764,11 @@ following steps:
 1. Let |cookieList| be a set of cookies, initially empty.
 1. [=list/For each=] cookie |cookie| in the [=cookie store=]:
     1. If |cookie| is not [=partitioned cookie|partitioned=]:
-        1. If |cookie|'s [=domain attribute=] is a [=domain-match=] with |host|, add |cookie| to |cookieList|; otherwise, continue.
+        1. If |cookie|'s [=domain attribute=] is a [=domain-match=] with |host|, add |cookie| to |cookieList|; otherwise, [=iteration/continue=].
     1. If |cookie| is [=partitioned cookie|partitioned=]:
         1. If the top-level [=site=] in |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("http", |host|), add |cookie| to |cookieList|.
         1. If the top-level [=site=] in |cookie|'s [=partition key=] is [=same site=] with the [=site=] ("https", |host|), add |cookie| to |cookieList|.
-        1. Otherwise, continue.
+        1. Otherwise, [=iteration/continue=].
 1. [=list/For each=] |cookie| in |cookieList|:
     1. Remove |cookie| from the [=cookie store=].
 


### PR DESCRIPTION
Namely, when deleting cookies for a host:

- Preserve cookies for that host partitioned under other sites, but
- delete cookies partitioned under sites with that host.

And change non-cookie storage deletion:

- from looking at the storage key's origin
- to looking at the storage key's top-level site.

Fixes #75.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/svendlarsen/nav-tracking-mitigations/pull/78.html" title="Last updated on Jul 22, 2024, 6:21 PM UTC (7fd9126)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/78/d6335ec...svendlarsen:7fd9126.html" title="Last updated on Jul 22, 2024, 6:21 PM UTC (7fd9126)">Diff</a>