### PR TITLE
Disambiguate `remote end steps` dfn link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -59,6 +59,11 @@ spec: PARTITIONED-COOKIES; urlPrefix: https://datatracker.ietf.org/doc/html/draf
         text: partitioned cookie; url: section-2.1
         text: partition key; url: section-2.2
 </pre>
+<pre class="link-defaults">
+spec:webdriver2
+    type:dfn
+        text:remote end steps
+</pre>
 
 <section class="non-normative">
 <h2 id="intro">Introduction</h2>


### PR DESCRIPTION
Running `bikeshed` on main yields the following output:

```
LINE ~837: Multiple possible 'remote end steps' dfn refs.
Arbitrarily chose https://patcg-individual-drafts.github.io/private-aggregation-api/#remote-end-steps
To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
spec:private-aggregation-api; type:dfn; text:remote end steps
spec:webdriver2; type:dfn; text:remote end steps
[=remote end steps=]
 ✔  Successfully generated, with 1 linking errors
```

i.e., bikeshed selects the wrong dfn link for `remote end steps`.

With this change, running `bikeshed` produces no warnings and correctly links to the webdriver spec's dfn for `remote end steps`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/svendlarsen/nav-tracking-mitigations/pull/84.html" title="Last updated on Oct 15, 2024, 6:04 PM UTC (de1ad76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/84/65e00b1...svendlarsen:de1ad76.html" title="Last updated on Oct 15, 2024, 6:04 PM UTC (de1ad76)">Diff</a>