### PR TITLE
End extended navigation on tab close

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -724,9 +724,12 @@ To run the <dfn>bounce tracking timer</dfn> algorithm given a [=moment=] on the
 </div>
 
 This algorithm is called when detecting the end of an [=extended navigation=]. This could happen
-if a user-initiated navigation is detected in [=process navigation start for bounce tracking=],
-or if the client bounce detection timer expires after [=process response received for bounce tracking=]
-without observing a client redirect.
+if:
+
+-  a user-initiated navigation is detected in [=process navigation start for bounce tracking=];
+-  the client bounce detection timer expires after [=process response received for bounce tracking=]
+     without observing a client redirect; or,
+-  the associated [=top-level traversable=]'s <a spec="html">is closing</a> is set to true.
 
 <div algorithm>
 


### PR DESCRIPTION
Specify that the extended navigation ends when the associated tab is about to close (i.e., top-level traversable is closing).

Fixes #83.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/svendlarsen/nav-tracking-mitigations/pull/85.html" title="Last updated on Oct 15, 2024, 6:36 PM UTC (a09fe80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/85/00cf8bb...svendlarsen:a09fe80.html" title="Last updated on Oct 15, 2024, 6:36 PM UTC (a09fe80)">Diff</a>