### PR TITLE
Fix an incorrect reference to "storage access set" when recording user activation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -555,7 +555,7 @@ given a [=request=] |request|, perform the following steps:
 1. Let |site| be the result of running [=obtain a site=] given |origin|.
 1. [=set/Append=] |site|'s [=host=] to |topLevelTraversable|'s
     [=top-level traversable/bounce tracking record=]'s
-    [=bounce tracking record/storage access set=].
+    [=bounce tracking record/user activation set=].
 
 </div>
 


### PR DESCRIPTION
Updating #70 with correct xref.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/89.html" title="Last updated on Oct 23, 2024, 2:56 PM UTC (d0ee323)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/89/25abc2b...amaliev:d0ee323.html" title="Last updated on Oct 23, 2024, 2:56 PM UTC (d0ee323)">Diff</a>