### PR TITLE
Fix logic to add initial host to user activation set

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -498,19 +498,19 @@ To <dfn>process navigation start for bounce tracking</dfn> given a [=navigable=]
         [=bounce tracking record=] with [=bounce tracking record/initial host=]
         set to |initialHost|.
 
-Note: This includes the case where the current navigation was initiated by another navigable, e.g. when opening
-    a link in a new tab. In this case, |sourceDocument| is set to the opener Document, and the new bounce tracking
-    record has its [=bounce tracking record/initial host=] set to the opener host. This ensures that trackers opened
-    in new tabs are detected as distinct from the [=bounce tracking record/initial host=] in the new  [=bounce tracking record=].
+    Note: This includes the case where the current navigation was initiated by another navigable, e.g. when opening
+        a link in a new tab. In this case, |sourceDocument| is set to the opener Document, and the new bounce tracking
+        record has its [=bounce tracking record/initial host=] set to the opener host. This ensures that trackers opened
+        in new tabs are detected as distinct from the [=bounce tracking record/initial host=] in the new  [=bounce tracking record=].
 
 1. Otherwise,
     1. If |sourceSnapshotParams|'s <a spec="html">has transient activation</a> is true:
         1. Run [=record stateful bounces for bounce tracking=] given |navigable|'s [=navigable/active document=]'s [=relevant global object=].
         1. Set |navigable|'s [=top-level traversable/bounce tracking record=] to a new [=bounce tracking record=] with
             [=bounce tracking record/initial host=] set to |initialHost|.
-        1. [=set/Append=] |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s
-            [=bounce tracking record/user activation set=].
     1. Otherwise, add |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s [=bounce tracking record/bounce set=].
+1. If |sourceSnapshotParams|'s <a spec="html">has transient activation</a> is true:
+    1. [=set/Append=] |initialHost| to |navigable|'s [=top-level traversable/bounce tracking record=]'s [=bounce tracking record/user activation set=].
 
 </div>
 


### PR DESCRIPTION
Responding to comment: https://github.com/whatwg/compat/pull/253/files/af104ee53d9e400a5fe58c19e508cf1eb88b3568#r1812898119 regarding where to add initial host to user activation set


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/amaliev/nav-tracking-mitigations/pull/90.html" title="Last updated on Oct 23, 2024, 4:30 PM UTC (91ba066)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/privacycg/nav-tracking-mitigations/90/9cb9339...amaliev:91ba066.html" title="Last updated on Oct 23, 2024, 4:30 PM UTC (91ba066)">Diff</a>