### PR TITLE
Fix local bikeshed build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,27 +16,29 @@ SHELL=/bin/bash -o pipefail
 all: publish update-explainer-toc
 
 clean:
-	rm -rf build *~
+	rm -rf index.html *~
 
-publish: build/index.html
+publish: index.html
 
 update-explainer-toc: README.md Makefile
 	doctoc $< --title "## Table of Contents" > /dev/null
 
-build/index.html: index.bs Makefile
-	mkdir -p build
+index.html: index.bs Makefile
 	bikeshed --die-on=warning spec $< $@
 
+# Build the spec using a remote version of bikeshed.
+#
+# Note that the remote bikeshed tool does not support uploading images and will
+# give a warning. Hence it will fail unless the warnings are allowed.
 remote: index.bs
-	mkdir -p build
 	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
-	                       --output build/index.html \
+	                       --output index.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
-	                       -F die-on=warning \
+	                       -F die-on=fatal \
 	                       -F file=@index.bs) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
-		echo ""; cat build/index.html; echo ""; \
-		rm -f build/index.html; \
+		echo ""; cat index.html; echo ""; \
+		rm -f index.html; \
 		exit 22 \
 	);

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,8 @@
 #
 #     python3 -m pip install bikeshed && bikeshed update
 
-# It also assumes you have doctoc installed. This is a tool that
-# automatically generates Table of Contents for Markdown files. It can
-# be installed like any other NPM module:
-#
-#    npm install -g doctoc
-
 SHELL=/bin/bash -o pipefail
-.PHONY: all publish clean update-explainer-toc remote
+.PHONY: all publish clean remote
 .SUFFIXES: .bs .html
 
 all: publish update-explainer-toc
@@ -19,9 +13,6 @@ clean:
 	rm -rf index.html *~
 
 publish: index.html
-
-update-explainer-toc: README.md Makefile
-	doctoc $< --title "## Table of Contents" > /dev/null
 
 index.html: index.bs Makefile
 	bikeshed --die-on=warning spec $< $@

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Navigation-based Tracking Mitigations
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents
+
+- [Stakeholder Feedback / Opposition](#stakeholder-feedback--opposition)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 Work in this repository analyzes the problem of navigation-based cross-site
 tracking and seeks to change browser behavior in order to prevent it. See the
 **[Navigational-Tracking Mitigations

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # Navigation-based Tracking Mitigations
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents
-
-- [Stakeholder Feedback / Opposition](#stakeholder-feedback--opposition)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 Work in this repository analyzes the problem of navigation-based cross-site
 tracking and seeks to change browser behavior in order to prevent it. See the
 **[Navigational-Tracking Mitigations

--- a/index.bs
+++ b/index.bs
@@ -186,7 +186,7 @@ specification's mitigations. It will define a few classes of actors with the
 ability to modify websites in particular ways. Then it will define what
 cross-site information each of these actors can or cannot learn.
 
-<h3 id="threat-actors">Threat actors</h2>
+<h3 id="threat-actors">Threat actors</h3>
 
 TODO
 
@@ -583,7 +583,7 @@ Insert the following steps in the <a spec="storage">obtain a storage bottle map<
 
 Issue(whatwg/storage#165): This patch has to be run whenever a site accesses non-cookie storage.
 <a spec="storage">Obtain a storage bottle map</a> is the intended hook for this, but it does not currently have full coverage across specs that use storage.
-So this patch is not comprehensive.</p>
+So this patch is not comprehensive.
 
 <div algorithm>
 


### PR DESCRIPTION
The makefile targets don't work due to minor errors. This PR fixes those errors such that building the spec locally works from the makefile. These are the specific changes:

* Change out mismatched html tags.
* Add a table of contents to `README.md` so `doctoc` will not modify the file at HEAD.
* Remove usage of the `build` directory. (The diagram in the spec won't render properly otherwise. Also outputting `index.html` in the root is consistent with that the GitHub action does.)
* Allow warnings with the remote build target. Remote `bikeshed` does not support taking in images, so it will always have a warning.

In the future, I propose removing `doctoc` and the remote build target altogether. The table of contents is somewhat nonexistent, so `doctoc` is an unnecessary dependency. The remote build already has degraded service, so using a local version of `bikeshed` make more sense. (However, for this PR, I'd prefer to only fix what's broken.)