### PR TITLE
Include local build instructions in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # This Makefile assumes you have a local install of bikeshed. Like any
 # other Python tool, you install it with pip:
 #
-#     python3 -m pip install bikeshed && bikeshed update
+#     pipx install bikeshed && bikeshed update
 
 SHELL=/bin/bash -o pipefail
 .PHONY: all publish clean remote
 .SUFFIXES: .bs .html
 
-all: publish update-explainer-toc
+all: publish
 
 clean:
 	rm -rf index.html *~

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ broadly on all navigation-based tracking mechanisms.
 
 The spec is written in [Bikeshed](https://speced.github.io/bikeshed/) and is
 found in [`index.bs`](index.bs). You will need to install Bikeshed to build the
-spec.
+spec:
 
 ```sh
 pipx install bikeshed
 ```
 
 To build the spec, use the default Makefile target, and it will generate an
-`index.html` containing the spec.
+`index.html` containing the spec:
 
 ```sh
 Make

--- a/README.md
+++ b/README.md
@@ -16,8 +16,19 @@ of [proposal 6](https://github.com/privacycg/proposals/issues/6) of the [Privacy
 Community Group](https://privacycg.github.io/), but this work focuses more
 broadly on all navigation-based tracking mechanisms.
 
-## Stakeholder Feedback / Opposition
+## Local development
 
-- [Implementor A] : Positive
-- [Stakeholder B] : No signals
-- [Implementor C] : Negative
+The spec is written in [Bikeshed](https://speced.github.io/bikeshed/) and is
+found in [`index.bs`](index.bs). You will need to install Bikeshed to build the
+spec.
+
+```sh
+pipx install bikeshed
+```
+
+To build the spec, use the default Makefile target, and it will generate an
+`index.html` containing the spec.
+
+```sh
+Make
+```


### PR DESCRIPTION
This PR adds instructions in the README for building the spec. It also cleans up a reference to the removed `update-explainer-toc` Makefile target and removes the `Stakeholder Feedback / Opposition` section (which held incorrect templated information).