### PR TITLE
Update main discussion link in dual-use explainer

### DIFF
--- a/explainers/bounce-tracking-mitigations-for-dual-use-sites.md
+++ b/explainers/bounce-tracking-mitigations-for-dual-use-sites.md
@@ -8,7 +8,7 @@ Alternatively: URL-Level Bounce Tracking Mitigations
 
 ## Participate
 
-- [Issue tracker / discussion forum](https://github.com/privacycg/nav-tracking-mitigations/issues)
+- [Issue tracker / discussion forum](https://github.com/privacycg/nav-tracking-mitigations/issues/106)
 
 ## Introduction
 


### PR DESCRIPTION
Previously the main link to participate in discussing the explainer pointed to the [main `nav-tracking-mitigations` issues page](https://github.com/privacycg/nav-tracking-mitigations/issues), but there's now an issue for general discussion of the explainer, so the link should be updated.